### PR TITLE
Make external links open in new tab

### DIFF
--- a/source/_themes/nginx/static/nginx-theme.js
+++ b/source/_themes/nginx/static/nginx-theme.js
@@ -105,4 +105,10 @@
 
     });
 
+    $('a.reference.external').each(function() {
+        $(this).click(function(event) {
+            event.preventDefault(); event.stopPropagation();window.open(this.href, '_blank');
+        });
+    });
+
 })(jQuery);


### PR DESCRIPTION
A little bit of a hacky workaround, using JS to do the dirty work.

Fixes #145