### PR TITLE
Added function in header to rewrite anchor tags

### DIFF
--- a/source/_themes/nginx/layout.html
+++ b/source/_themes/nginx/layout.html
@@ -165,6 +165,15 @@
     {%- endif %}
 {%- endblock %}
 {%- block extrahead %} {% endblock %}
+    <script type="text/javascript">
+        // workaround for rewriting anchor tags
+        $(function() {
+            var parts = window.location.hash.split('#', 2);
+            var fixed = parts[0] + '#' + parts[1].replace(/[\W_]/g, '-');
+            window.location.hash = fixed;
+        });
+    </script>
+
     <link rel='stylesheet' id='nginx-theme-style-css'
           href='{{ pathto('_static/nginx-theme.css?ver=1438882823', 1) }}'
           type='text/css' media='all'/>


### PR DESCRIPTION
**Fixes #139**

Added a script tag with a jQuery function to `_themes/nginx/layout.html` that replaces all non-alphanumeric characters in anchor tags with hyphens.

**Note**
For some reason the header seemed to be misbehaving while I tested this, but I don't think that it's related to this change. Just something to look out for. 