### PR TITLE
Standardize NGINX capitalization in all pages except modules/*

### DIFF
--- a/source/community/faq.rst
+++ b/source/community/faq.rst
@@ -32,7 +32,7 @@ Is it safe to use the development branch in production?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In general, all releases (development or otherwise) are quite stable.
 This site runs the latest development version at all times.
-Many nginx users tend to represent an "early adopter" crowd, so a large segment is using the bleeding-edge version at any given point.
+Many NGINX users tend to represent an "early adopter" crowd, so a large segment is using the bleeding-edge version at any given point.
 The major and most important point about the development version is that it can occasionally break APIs for third-party modules (APIs are sometimes changed in the development branch).
 Other than that, it gets all non-emergency bugfixes first.
 

--- a/source/community/resources.rst
+++ b/source/community/resources.rst
@@ -17,15 +17,15 @@ Developer Resources
 
 English Guides
 --------------
-* `EMiller's Guide to Nginx Module Development <http://www.evanmiller.org/nginx-modules-guide.html>`_ (Evan Miller)
-* `EMiller's Advanced Topics In Nginx Module Development <http://www.evanmiller.org/nginx-modules-guide-advanced.html>`_ (Evan Miller and Grzegorz Nosek)
+* `EMiller's Guide to NGINX Module Development <http://www.evanmiller.org/nginx-modules-guide.html>`_ (Evan Miller)
+* `EMiller's Advanced Topics In NGINX Module Development <http://www.evanmiller.org/nginx-modules-guide-advanced.html>`_ (Evan Miller and Grzegorz Nosek)
 * Slides of agentzh's `Introduction to nginx.conf scripting <http://agentzh.org/misc/slides/nginx-conf-scripting/>`_ talk in Beijing (use arrow keys to navigate)
 * Slides of agentzh's `Recent developments in nginx.conf scripting <http://agentzh.org/misc/slides/recent-dev-nginx-conf/>`_ talk in Beijing (use arrow keys to navigate)
-* Slides of Joshua Zhu's `Nginx Internals <http://www.slideshare.net/joshzhu/nginx-internals>`_ talk in Guangzhou
+* Slides of Joshua Zhu's `NGINX Internals <http://www.slideshare.net/joshzhu/nginx-internals>`_ talk in Guangzhou
 * `NGINX source code cross-reference <http://lxr.evanmiller.org/http/source/>`_
 * `nginx-devel mailing list archive <http://mailman.nginx.org/pipermail/nginx-devel/>`_
 * `"nginx" chapter in The Architecture of Open Source Applications Volume II <http://www.aosabook.org/en/nginx.html>`_
-* `"Nginx Secure Web Server" how-to at calomel.org <https://calomel.org/nginx.html>`_
+* `"NGINX Secure Web Server" how-to at calomel.org <https://calomel.org/nginx.html>`_
 * Notes about :doc:`../start/topics/examples/headers_management`
 
 
@@ -46,7 +46,7 @@ Chinese Guides
 --------------
 * `NGINX Variable Tutorials <http://blog.sina.com.cn/openresty>`_ by `agentzh <http://agentzh.org>`_
 * `NginxCodeReview <http://code.google.com/p/nginxsrp/wiki/NginxCodeReview>`_ by chaoslawful and rainx
-* `Chinese version of "Emiller's Guide to Nginx Module Development" <http://code.google.com/p/emillers-guide-to-nginx-module-chn/>`_
+* `Chinese version of "Emiller's Guide to NGINX Module Development" <http://code.google.com/p/emillers-guide-to-nginx-module-chn/>`_
 
 ..
    Dead links now
@@ -62,20 +62,20 @@ Other Resources
 
 ..
    Geo database is no longer downloadable from WIP Mania
-   * `Geolocation database for Nginx in CIDR format (countries by IP) <http://www.wipmania.com/en/base/>`_ 
+   * `Geolocation database for NGINX in CIDR format (countries by IP) <http://www.wipmania.com/en/base/>`_ 
 
-* `Experiment to automatically convert Apache rewrites to Nginx rewrites <http://www.anilcetin.com/convert-apache-htaccess-to-nginx/>`_
+* `Experiment to automatically convert Apache rewrites to NGINX rewrites <http://www.anilcetin.com/convert-apache-htaccess-to-nginx/>`_
 * `Parsing PHP sessions in NGINX <http://mauro-stettler.blogspot.com/2011/06/php-session-parser-in-production.html>`_
 * `PyMunin - Multigraph Munin Plugins in Python <http://aouyar.github.io/PyMunin/>`_ - PyMunin includes a Multigraph Munin Plugin for monitoring NGINX using http_stub_status module. Graphs active connections, connection rate, request rate, and average requests per connection.
 * :doc:`why_use_it`
 
 ..
    Dead links now
-   * `Nginx and Memcached, a 400% boost! <https://www.igvita.com/2008/02/11/nginx-and-memcached-a-400-boost/>`_
-   * `nWeb Script - Easy installer script for Debian / Ubuntu <http://thehook.eu/tools/nweb/>`_ (Installs nginx, with PHP support and MySQL)
-   * `Intellij IDEA plugin for integration with nginx <http://code.google.com/p/idea-nginx/>`_
-   * `Unofficial Debian repository with the latest Nginx release <http://debian.perusio.net>`_
-   * `Nginx vs Apache <http://www.joeandmotorboat.com/2008/02/28/apache-vs-nginx-web-server-performance-deathmatch/>`_
-   * `ISPConfig support for Nginx <http://www.howtoforge.com/forums/showthread.php?p=161742>`_
-   * `Latest bug reports about nginx found by bugspy.net <http://bugspy.net/search/?q=nginx>`_
-   * `Using nginx as reverse-proxy <http://paulohiga.com/posts/nginx-proxy-reverso-php-apache.php>`_
+   * `NGINX and Memcached, a 400% boost! <https://www.igvita.com/2008/02/11/nginx-and-memcached-a-400-boost/>`_
+   * `nWeb Script - Easy installer script for Debian / Ubuntu <http://thehook.eu/tools/nweb/>`_ (Installs NGINX, with PHP support and MySQL)
+   * `Intellij IDEA plugin for integration with NGINX <http://code.google.com/p/idea-nginx/>`_
+   * `Unofficial Debian repository with the latest NGINX release <http://debian.perusio.net>`_
+   * `NGINX vs Apache <http://www.joeandmotorboat.com/2008/02/28/apache-vs-nginx-web-server-performance-deathmatch/>`_
+   * `ISPConfig support for NGINX <http://www.howtoforge.com/forums/showthread.php?p=161742>`_
+   * `Latest bug reports about NGINX found by bugspy.net <http://bugspy.net/search/?q=nginx>`_
+   * `Using NGINX as reverse-proxy <http://paulohiga.com/posts/nginx-proxy-reverso-php-apache.php>`_

--- a/source/community/why_use_it.rst
+++ b/source/community/why_use_it.rst
@@ -45,10 +45,10 @@ resources.
 -- Matthew Prince, co-founder and CEO of CloudFlare
 
 
-Both servers [Apache and Nginx] are capable of serving a huge number of requests per
+Both servers [Apache and NGINX] are capable of serving a huge number of requests per
 second, but Apache's performance start decreasing as you add more concurrent
-connections whereas Nginx's performance almost doesn't drop!
-But here comes the best bit: because Nginx is event-based it doesn't need to
+connections whereas NGINX's performance almost doesn't drop!
+But here comes the best bit: because NGINX is event-based it doesn't need to
 spawn new processes or threads for each request, so its memory usage is very low.
 Throughout my benchmark it just sat at 2.5MB of memory while Apache was using a
 lot more.
@@ -56,25 +56,25 @@ lot more.
 -- `WebFaction <http://blog.webfaction.com/2008/12/a-little-holiday-present-10000-reqssec-with-nginx-2/>`__
 
 
-I ran a simple test against Nginx v0.5.22 and Apache v2.2.8 using ab (Apache's
+I ran a simple test against NGINX v0.5.22 and Apache v2.2.8 using ab (Apache's
 benchmarking tool). During the tests, I monitored the system with vmstat and top.
-The results indicate that Nginx outperforms Apache when serving static content.
+The results indicate that NGINX outperforms Apache when serving static content.
 Both servers performed best with a concurrency of 100. Apache used four worker
 processes (threaded mode), 30% CPU and 17MB of memory to serve 6,500 requests per
-second. Nginx used one worker, 15% CPU and 1MB of memory to serve 11,500 requests
+second. NGINX used one worker, 15% CPU and 1MB of memory to serve 11,500 requests
 per second.
 
 -- `Linux Journal <http://www.linuxjournal.com/article/10108>`__
 
 
 Apache is like Microsoft Word, it has a million options but you only need
-six. Nginx does those six things, and it does five of them 50 times faster
+six. NGINX does those six things, and it does five of them 50 times faster
 than Apache.
 
 -- `Chris Lea <http://maisonbisson.com/post/12249/chris-lea-on-nginx-and-wordpress>`_
 
 
-I currently have Nginx doing reverse proxy of over tens of millions of
+I currently have NGINX doing reverse proxy of over tens of millions of
 HTTP requests per day (that's a few hundred per second) on a single server.
 At peak load it uses about 15MB RAM and 10% CPU on my particular configuration
 (FreeBSD 6).
@@ -87,9 +87,9 @@ than 20MB per hour (and uses more CPU, but not significantly more).
 `TurboGears mailing list <http://markmail.org/message/q3smhtnlujh2mvpu>`_, 2006-08-24
 
 
-We are currently using Nginx 0.6.29 with the upstream hash module which
+We are currently using NGINX 0.6.29 with the upstream hash module which
 gives us the static hashing we need to proxy to Varnish. We are regularly
-serving about 8-9k requests/second and about 1.2Gbit/sec through a few Nginx
+serving about 8-9k requests/second and about 1.2Gbit/sec through a few NGINX
 instances and have plenty of room to grow!
 
 -- `Wordpress.com <https://barry.wordpress.com/2008/04/28/load-balancer-update/>`_
@@ -111,8 +111,8 @@ instances and have plenty of room to grow!
    -- `Emmett Shear <http://blog.emmettshear.com/post/2008/03/03/Dont-use-Pound-for-load-balancing>`_
 
 
-...we are using nginx as a primary software for free hosting platforms. I have
-developed specific modules for banner inserting and stats calculation in nginx
+...we are using NGINX as a primary software for free hosting platforms. I have
+developed specific modules for banner inserting and stats calculation in NGINX
 and now our central server can handle about 150-200Mbit/s of highly fragmented
 http-traffic (all files are small).
 I think, this is really good result because with any possible tunings of Apache
@@ -121,8 +121,8 @@ on the same servers we were not able to handle even 60-80Mbit/s.
 -- `Alexey Kovyrin <http://kovyrin.net/2006/04/04/nginx-small-powerful-web-server/>`_
 
 
-A while back, we changed our frontend IMAP/POP proxy from perdition to nginx...
-[and] we’ve now switched over to using nginx for our frontend web proxy as well...
+A while back, we changed our frontend IMAP/POP proxy from perdition to NGINX...
+[and] we’ve now switched over to using NGINX for our frontend web proxy as well...
 The net result of all this is that each frontend proxy server currently maintains
 over 10,000 simultaneous IMAP, POP, Web & SMTP connections (including many SSL
 ones) using only about 10% of the available CPU.
@@ -130,16 +130,16 @@ ones) using only about 10% of the available CPU.
 -- `FastMail.fm blog <http://blog.fastmail.com/2007/01/04/webimappop-frontend-proxies-changed-to-nginx/>`_
 
 
-We recently switched over our static content webserver over to Nginx,
+We recently switched over our static content webserver over to NGINX,
 easily the most impressive webserver I’ve seen in years. We’re running
 it on a machine with 8Gb of memory (along with some other stuff), but
-the nginx process is only using a ridiculously small 1.4Mb. In other words,
+the NGINX process is only using a ridiculously small 1.4Mb. In other words,
 it barely registers in any measurable way.
 
 -- `Philip Jacob <http://seventhfloor.whirlycott.com/2007/10/05/singing-the-praises-of-nginx/>`_
 
 
-We've replaced our Squid (reverse proxy) + Apache setup with nginx, and
+We've replaced our Squid (reverse proxy) + Apache setup with NGINX, and
 load average as well as CPU usage have been reduced by half. In addition
 to that our benchmarks show that the new setup can handle about two to
 three times as many requests per second (RPS) as the old setup.
@@ -149,8 +149,8 @@ three times as many requests per second (RPS) as the old setup.
 
 We've done some `benchmarks <https://timmehosting.de/benchmarks>`__ for
 CMS systems such as Wordpress, Drupal, Joomla, TYPO3, etc., and the
-result is that nginx delivers pages up to 50% faster than Apache. At the
-same time nginx can handle up to 177% as many requests per second (RPS)
+result is that NGINX delivers pages up to 50% faster than Apache. At the
+same time NGINX can handle up to 177% as many requests per second (RPS)
 as Apache.
 
 -- `Timme Hosting <https://timmehosting.de>`_

--- a/source/conf.py
+++ b/source/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Nginx Wiki documentation build configuration file, created by
+# NGINX Wiki documentation build configuration file, created by
 # sphinx-quickstart on Fri Apr 24 23:04:57 2015.
 #
 # This file is execfile()d with the current directory set to its
@@ -116,9 +116,9 @@ rst_epilog = """
 master_doc = 'index'
 
 # General information about the project.
-project = u'Nginx Wiki'
-copyright = u'2015, Nginx Inc.'
-author = u'Nginx Inc.'
+project = u'NGINX Wiki'
+copyright = u'2015, NGINX Inc.'
+author = u'NGINX Inc.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -294,8 +294,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'NginxWiki.tex', u'Nginx Wiki Documentation',
-   u'Nginx Inc.', 'manual'),
+  (master_doc, 'NginxWiki.tex', u'NGINX Wiki Documentation',
+   u'NGINX Inc.', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -324,7 +324,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'nginxwiki', u'Nginx Wiki Documentation',
+    (master_doc, 'nginxwiki', u'NGINX Wiki Documentation',
      [author], 1)
 ]
 
@@ -338,7 +338,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'NginxWiki', u'Nginx Wiki Documentation',
+  (master_doc, 'NginxWiki', u'NGINX Wiki Documentation',
    author, 'NginxWiki', 'One line description of project.',
    'Miscellaneous'),
 ]
@@ -358,7 +358,7 @@ texinfo_documents = [
 # Many websites use anchors for JS which confuses linkcheck
 linkcheck_anchors = False
 
-# Some links don't run Nginx and can be slow
+# Some links don't run NGINX and can be slow
 linkcheck_timeout = 60
 
 linkcheck_ignore = [

--- a/source/contributing/writing_docs.rst
+++ b/source/contributing/writing_docs.rst
@@ -118,7 +118,7 @@ There are internal links as well as external links that are possible.
 
    .. _reference-location:
 
-   `Nginx Website <https://www.nginx.com/>`_
+   `NGINX Website <https://www.nginx.com/>`_
 
    A link to another document: :doc:`index`
 
@@ -126,7 +126,7 @@ There are internal links as well as external links that are possible.
 
 .. _reference-location:
 
-`Nginx Website <https://www.nginx.com/>`_
+`NGINX Website <https://www.nginx.com/>`_
 
 A link to another document: :doc:`index`
 
@@ -229,7 +229,7 @@ Sphinx can highlight the syntax of code blocks. For example:
      return 0;
    }
 
-There is also syntax highlighting for Nginx configuration files, here is an example of this with line numbers:
+There is also syntax highlighting for NGINX configuration files, here is an example of this with line numbers:
 
 .. code-block:: rst
 
@@ -324,8 +324,8 @@ Which generates:
    This is a See Also
 
 
-Nginx Wiki specific rols
-------------------------
+NGINX Wiki specific roles
+-------------------------
 
 A few extra roles have been added to assist with creating documentation for this wiki.
 

--- a/source/start/index.rst
+++ b/source/start/index.rst
@@ -114,12 +114,12 @@ Full Stack HOWTOs
 Pre-canned Configurations
 -------------------------
 
-As you learned in the tutorials, most Nginx configuration files are very
+As you learned in the tutorials, most NGINX configuration files are very
 similar. You can apply the same logic to most web applications and achieve the
 desired result. There are some applications that have weird little quirks that
 tend to throw a wrench in things.
 
-Nginx happens to have a very well rounded community that has worked to first
+NGINX happens to have a very well rounded community that has worked to first
 address these quirks and then share the resulting configurations. This has
 resulted in many "copy and paste" configurations that are almost guaranteed
 to work.
@@ -179,7 +179,7 @@ to work.
 Other Examples
 --------------
 
-Of course, Nginx can do much more. We're barely scratching the surface. If
+Of course, NGINX can do much more. We're barely scratching the surface. If
 you're interested, you can take a look at some other examples that have been
 developed.
 
@@ -212,7 +212,7 @@ developed.
 * `NGINX + SSL + SPDY <https://www.mare-system.de/guide-to-nginx-ssl-spdy-hsts/>`_
 * `NGINX + PHP FPM + APC on CentOS 6 <http://www.binarytides.com/install-nginx-php-fpm-centos/>`_
 * `Adding new vhosts with NGINX, PHP-FPM and Bash <http://www.sebdangerfield.me.uk/2012/05/nginx-and-php-fpm-bash-script-for-creating-new-vhosts-under-separate-fpm-pools/>`_
-* `Serving an iPhone website with Nginx <http://nicknotfound.com/2009/01/12/iphone-website-with-nginx/>`_
+* `Serving an iPhone website with NGINX <http://nicknotfound.com/2009/01/12/iphone-website-with-nginx/>`_
 * :doc:`topics/examples/hardwarelberrors`
 * :doc:`topics/examples/xsendfile`
 * :doc:`topics/examples/memcachepreload`

--- a/source/start/topics/depth/ifisevil.rst
+++ b/source/start/topics/depth/ifisevil.rst
@@ -145,7 +145,7 @@ In case you think you found an example which isn't listed here - it's a good ide
 Why this happens and still not fixed
 ------------------------------------
 
-Directive "if" is part of rewrite module which evaluates instructions imperatively.  On the other hand, nginx configuration in general is declarative.  At some point due to users demand an attempt was made to enable some non-rewrite directives inside "if", and this lead to situation we have now.  It mostly works, but... see above.
+Directive "if" is part of rewrite module which evaluates instructions imperatively.  On the other hand, NGINX configuration in general is declarative.  At some point due to users demand an attempt was made to enable some non-rewrite directives inside "if", and this lead to situation we have now.  It mostly works, but... see above.
 
 Looks like the only correct fix would be to disable non-rewrite directives inside if completely.  It would break many configuration out there though, so wasn't done yet.
 

--- a/source/start/topics/examples/SSL-Offloader.rst
+++ b/source/start/topics/examples/SSL-Offloader.rst
@@ -11,12 +11,12 @@ I want to thank Igor Sysoev for this nice piece of software.
 For me, this is the only way to contribute something to this great project.
 I've tried to document the whole picture of building what we simply call our "SSL-Proxy" (aka. SSL/TLS/HTTPS-Offloader/-Accelerator/-Terminator/-Dispatcher/Reverse-Proxy/Loadbalancer etc.).
 
-In our company we use Nginx as a reverse proxy, serving HTTPS to the client while getting the content via HTTP from the multiple backends.
+In our company we use NGINX as a reverse proxy, serving HTTPS to the client while getting the content via HTTP from the multiple backends.
 We have two virtual machines "connected" with VRRP to one cluster, acting as a frontend for about 80 Tomcat servers (and some IIS, Apache/PHP ...), each with one or more applications.
 There were many reasons for this structure: One CI (ITIL: change item) for SSL certificates, customer demands (one URL xyz with multiple services), simple but effective failover mechanism for changes and so on.
 
 **Update 2014, success story:**
-  This Nginx setup as a reverse ssl-proxy with our "super-url's" works perfectly for over 7 years (in this time we changed the ubuntu versions several times - from hardy to precise).
+  This NGINX setup as a reverse ssl-proxy with our "super-url's" works perfectly for over 7 years (in this time we changed the ubuntu versions several times - from hardy to precise).
   Today only two applications left and couldn't be included in this scheme.
   The configuration without comments has about 7000 lines.
   We have about 10 changes in the setup per week and we can do all of them on fly (using reload).
@@ -43,7 +43,7 @@ The server works very efficient:
 #. Hypervisor: VMware ESXi
 #. VM: 4x CPU (load: ~0.15), 768 MByte RAM (used: ~12%), 4 GByte HD
 #. Base system: Ubuntu 12.04.5/precise
-#. Working horse: Nginx 1.6.2-5+precise0 (`ppa:nginx/stable <https://launchpad.net/~nginx/+archive/ubuntu/stable>`_)
+#. Working horse: NGINX 1.6.2-5+precise0 (`ppa:nginx/stable <https://launchpad.net/~nginx/+archive/ubuntu/stable>`_)
 #. SSL-Library: LibSSL 1.0.1-4ubuntu5.21
 #. Entropy-Daemon: haveged 1.1-2
 #. VRRP daemon: Keepalived 1:1.2.2-3ubuntu1.1
@@ -231,7 +231,7 @@ For the second system change the values of "state" and "priority".
 HTTPS Addresses
 ^^^^^^^^^^^^^^^
 One possible solution is to use direct routing and not a NAT (network address translation).
-In this case you need local ip addresses with fit to the server of the nginx configuration.
+In this case you need local ip addresses with fit to the server of the NGINX configuration.
 In the file ``/etc/network/interfaces`` you can add a ``post-up`` command for the dummy (or loopback) interface like this.
 Don't forget to add the modules ``dummy`` to ``/etc/modules``.
 
@@ -300,7 +300,7 @@ Core Configuration
 nginx.conf
 ^^^^^^^^^^
 I decided to change not too much in the default config file ``/etc/nginx/nginx.conf``.
-The VM has four cores, each core get one fixed worker, and I wanted nginx to get an better priority than other processes.
+The VM has four cores, each core get one fixed worker, and I wanted NGINX to get an better priority than other processes.
 All other setting were included
 (the included file ``mime.types`` is taken from the project `HTML5-Boilerplate <https://github.com/h5bp/server-configs-nginx/blob/master/mime.types>`_).
 
@@ -492,7 +492,7 @@ We defined the SSL-Proxy as a network device and therefore the application is re
 backend.conf
 ^^^^^^^^^^^^
 We use this file to define the relation of two backend servers with an ID.
-The syntax of nginx only let you define these definitions global.
+The syntax of NGINX only let you define these definitions global.
 This means you have to touch two files if you define one new backend/upstream.
 
 .. code-block:: nginx
@@ -762,10 +762,10 @@ Remote Logging
 
 The Problem
 ^^^^^^^^^^^
-In few words: **Nginx doesn't support Syslog.**
+In few words: **NGINX doesn't support Syslog.**
 Therefore you have some possibilities, if you want Syslog support:
 
-#. Compile Nginx with the **syslog patch**:
+#. Compile NGINX with the **syslog patch**:
     I prefer to use the original packages ...
 #. Use a **syslog implementation with file support** (e.g. rsyslog with "imfile"):
     That's okay for the ``error.log``, but it is a bad idea for the space consuming ``access.log``, because you don't want to store these data a second time local.
@@ -782,7 +782,7 @@ Simple Solution
 
 
 2. Create a file **/etc/rsyslog.d/nginx.conf** for file monitoring. Repeat the part in the middle for every file you want to see in the syslog.
-   The last line is important, otherwise you will log these messages three times (nginx log, udp syslog and local syslog):
+   The last line is important, otherwise you will log these messages three times (NGINX log, udp syslog and local syslog):
 
   .. code-block:: nginx
 

--- a/source/start/topics/examples/coding_style.rst
+++ b/source/start/topics/examples/coding_style.rst
@@ -2,7 +2,7 @@
 .. meta::
    :description: Learn the coding style used in the NGINX source files by example.
 
-The Nginx source code is written in the C programming language by
+The NGINX source code is written in the C programming language by
 Kernighan and Ritchie and maintains a consistent style.
 
 -  K&R style indentation

--- a/source/start/topics/examples/djangofastcgi.rst
+++ b/source/start/topics/examples/djangofastcgi.rst
@@ -24,11 +24,11 @@ Assuming your sites are organised as::
 
 and you have placed the pid (and socket) file(s) in a ``RUNFILES_PATH`` folder (like in the script in the above link).
 
-Nginx configuration
+NGINX configuration
 -------------------
 
 Put this configuration in your nginx.conf file (or in a ``sites-{available/enabled}/`` conf file if you want to use the "include" instruction).
-It was working immediately with the default configuration from my Ubuntu Karmic, using the ubuntu repository version of Nginx (which provides ``/etc/init.d/nginx stop|start|restart``).
+It was working immediately with the default configuration from my Ubuntu Karmic, using the ubuntu repository version of NGINX (which provides ``/etc/init.d/NGINX stop|start|restart``).
 
 .. code-block:: nginx
 
@@ -109,7 +109,7 @@ From the "sites" folder:
 
    $ sudo spawn --factory=spawning.django_factory.config_factory siteYY.settings --port={PORT NUMBER}
 
-Nginx settings
+NGINX settings
 ^^^^^^^^^^^^^^
 
 We just configure it as a proxy to the port defined in spawn.
@@ -129,10 +129,10 @@ The location directive is now (the rest being the same as in the section Django 
         # proxy_set_header X-Forwarded-For $remote_addr;
     }
 
-Django + FastCGI + Nginx on RHEL4
+Django + FastCGI + NGINX on RHEL4
 ---------------------------------
 
-install nginx
+install NGINX
 ^^^^^^^^^^^^^
 
 .. code-block:: bash
@@ -151,7 +151,7 @@ install nginx
     $ make
     $ sudo make install
 
-nginx configuration
+NGINX configuration
 ^^^^^^^^^^^^^^^^^^^
 
 This example is overly complicated and needs to be cleaned up.
@@ -278,7 +278,7 @@ stop
 
    kill -9 `cat {project_location}/log/django.pid`
 
-nginx frontend
+NGINX frontend
 --------------
 
 start

--- a/source/start/topics/examples/embeddedperlsitemapsproxy.rst
+++ b/source/start/topics/examples/embeddedperlsitemapsproxy.rst
@@ -13,7 +13,7 @@ These sitemaps are useful to feed your urls to the search engines. http://www.si
 
 Normally it is the job of the site-owner/webmaster to submit these sites to the search engine. Some do and some dont.
 
-We wanted to serve all these sites dynamically and here is how it is done with nginx and perl module.
+We wanted to serve all these sites dynamically and here is how it is done with NGINX and perl module.
 
 Note: There might be other easier way of doing this but IANASEO.
 
@@ -44,7 +44,7 @@ So the ``robots.txt`` looks something like this
     sitemap: http://sitemaps.worldsoft-cms.info/ispman.net-sitemap.xml
 
 The domain-name.com is ofcoarse replaced with the correct name.
-This sends all sitemaps requests to a central server running nginx.
+This sends all sitemaps requests to a central server running NGINX.
 
 nginx.conf (related parts only):
 

--- a/source/start/topics/examples/fastcgiexample.rst
+++ b/source/start/topics/examples/fastcgiexample.rst
@@ -32,13 +32,13 @@ For example you might have an ``/etc/nginx/fastcgi.conf`` (or ``/etc/nginx/fastc
 
 This allows you to keep your individual FCGI configurations as simple as possible.
 You may also want to replace ``$document_root`` in ``SCRIPT_FILENAME`` and ``DOCUMENT_ROOT`` with an actual path, the ``$document_root`` variable is hardcoded and may not reflect your install (will cause variations on 'script not found' errors, usually).
-To use Nginx + Virtual Host + PHP you should ommit the ``SCRIPT_NAME`` variable in order for PHP to choose the correct ``DOCUMENT_ROOT``.
+To use NGINX + Virtual Host + PHP you should ommit the ``SCRIPT_NAME`` variable in order for PHP to choose the correct ``DOCUMENT_ROOT``.
 
 
 
 Spawning a FastCGI Process
 --------------------------
-Unlike Apache or Lighttpd, Nginx does not automatically spawn FCGI processes.
+Unlike Apache or Lighttpd, NGINX does not automatically spawn FCGI processes.
 You must start them separately.
 In fact, FCGI is a lot like proxying.
 There's a few ways to start FCGI programs, but luckily PHP5 will auto-spawn as many as you set in the ``PHP_FCGI_CHILDREN`` environment variable.
@@ -94,9 +94,9 @@ Install the usual way (for this debian init script, it's ``update-rc.d`` ``php-f
 
 
 
-Connecting Nginx to the running FastCGI Process
+Connecting NGINX to the running FastCGI Process
 -----------------------------------------------
-Now that the FCGI process is running, we must tell Nginx to proxy requests to it via the FCGI protocol:
+Now that the FCGI process is running, we must tell NGINX to proxy requests to it via the FCGI protocol:
 
 .. code-block:: nginx
 
@@ -105,7 +105,7 @@ Now that the FCGI process is running, we must tell Nginx to proxy requests to it
       fastcgi_pass  127.0.0.1:9000;
   }
 
-Restart Nginx.
+Restart NGINX.
 
 
 

--- a/source/start/topics/examples/hardwarelberrors.rst
+++ b/source/start/topics/examples/hardwarelberrors.rst
@@ -7,7 +7,7 @@ Hardware Loadbalancer Check Errors
 
 Some Hardware Load-balancers such Cisco's CSS and BigIP Products test the readiness of the backend Machines with  ``SYN-ACK-RST``.
 
-This behavior causes a 400 error in nginx.
+This behavior causes a 400 error in NGINX.
 
 With the `GEO Module <http://nginx.org/en/docs/http/ngx_http_geo_module.html>`_  and the ``if-Statement`` you can omit these entries:
 

--- a/source/start/topics/examples/headers_management.rst
+++ b/source/start/topics/examples/headers_management.rst
@@ -6,14 +6,14 @@ Managing request headers
 ------------------------
 
 As far as the
-:github:`Nginx.HeadersIn <peter-leonov/ngx_http_js_module/blob/master/src/classes/Request/HeadersIn.c>`
+:github:`NGINX.HeadersIn <peter-leonov/ngx_http_js_module/blob/master/src/classes/Request/HeadersIn.c>`
 and
-:github:`Nginx.HeadersOut <peter-leonov/ngx_http_js_module/blob/master/src/classes/Request/HeadersOut.c>`
+:github:`NGINX.HeadersOut <peter-leonov/ngx_http_js_module/blob/master/src/classes/Request/HeadersOut.c>`
 classes of
 the :github:`ngx\_http\_js\_module <peter-leonov/ngx_http_js_module>`
 implemented almost fully now we can talk about this ``headers_in`` and ``headers_out`` structs a little.
 
-The HTTP headers in nginx are split in two parts: the input request
+The HTTP headers in NGINX are split in two parts: the input request
 headers
 (`headers\_in <http://lxr.evanmiller.org/http/source/http/ngx_http_request.h#L162>`__
 structure) and the output request headers
@@ -22,7 +22,7 @@ structure). There is no such an entity as a response, all the data
 is stored in the same single request structure. The actual response data
 is constructed from the request data and the ``headers_out`` structure fields.
 
-All the things in nginx are highly optimized. No memory overhead caused
+All the things in NGINX are highly optimized. No memory overhead caused
 by strings copying, no memory leaks and alloc/free burden as far as
 memory is managed with pools, no wasted CPU cycles by comparing those
 strings again and again, everything is cached in a sane way, complicated
@@ -37,16 +37,16 @@ Lets talk about HTTP headers a little. All of us have seen lots
 of headers. And we know that the HTTP header is a very flexible data
 format. Client may send only one simple header, or many headers with
 the same name each on its own line, or even one big header split into
-many lines. It's a kinda mess. And nginx in its turn tries to rule the
+many lines. It's a kinda mess. And NGINX in its turn tries to rule the
 mess.
 
-nginx takes care of known frequently used headers (`list of known
+NGINX takes care of known frequently used headers (`list of known
 headers\_in <http://lxr.evanmiller.org/http/source/http/ngx_http_request.c#L80>`__).
 It parses it and stores in the handy place (direct pointer in ``headers_in``). 
 If a known header may consist of more then one value (Cookies or
-Cache-Control for example.) nginx could handle it with an array. And for
+Cache-Control for example.) NGINX could handle it with an array. And for
 a header that known to have a numeric value (Content-Length, Expires)
-nginx will parse the text and store it directly in the ``headers_in`` struct. All the 
+NGINX will parse the text and store it directly in the ``headers_in`` struct. All the 
 rest of headers are carefully stored in a simple list within the ``headers_in``
 structure, so nothing is been lost.
 
@@ -70,7 +70,7 @@ is a good example).
 This is good if you know at compile time which header you are going to
 read. But how do we get the header by its name at run time where the
 name is just a string? For this kind of situation we have a smart hash
-of headers ``cmcf->headers_in_hash``. If the header is known to nginx the header name is cached within this
+of headers ``cmcf->headers_in_hash``. If the header is known to NGINX the header name is cached within this
 hash and we can find the header value relatively fast. If the header
 hasn't been hashed we'll have to run through the full headers list and
 compare all headers names with our one. This isn't very fast but also
@@ -239,18 +239,18 @@ a pre-hashed key.
 How does hashed search work?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-At the configuration stage nginx creates a hash
+At the configuration stage NGINX creates a hash
 (`ngx\_hash\_t <http://lxr.evanmiller.org/http/ident?i=ngx_hash_t>`__)
 of known HTTP headers (as mentioned above). In each pair the key is a
-the header name and the value is a nginx header handler structure
+the header name and the value is a NGINX header handler structure
 (pretty smart structure, you know). In this structure we can see the
 header name, its handler on a stage of headers parsing (for internal
 use) and, the most interesting, the offset of the header value in the
 headers\_in struct. This offset is used to fill the appropriate field in
 the request struct when the request value is been adding. At the parsing
-stage nginx calculates a hash of the lowercased header name (HTTP
+stage NGINX calculates a hash of the lowercased header name (HTTP
 headers names are case-insensitive) and searches the header handler by
-this hash (in main conf headers has). If the handler is found nginx
+this hash (in main conf headers has). If the handler is found NGINX
 invokes it, otherwise just adds the key/value pair to the plain list of
 headers (``headers_in.headers``). Pretty simple if you know how it' made ;)
 
@@ -264,7 +264,7 @@ output header by its name at runtime.
 How can I set a header?
 -----------------------
 
-As far as nginx may store a header value in many places you have to be
+As far as NGINX may store a header value in many places you have to be
 careful setting a header. Every known header needs a special way to be
 set. If it is a numeric header you could set it three times: a plain
 key/value pair in the list, the pointer in headers\_in struct and the

--- a/source/start/topics/examples/imapauthenticatewithapacheperlscript.rst
+++ b/source/start/topics/examples/imapauthenticatewithapacheperlscript.rst
@@ -8,13 +8,13 @@ Using a Perl Script as the IMAP Auth Backend
 Using nginx-embedded-perl module on the same server as the imap/pop proxy as the auth backend
 
 .. note::
-   This solution will block entire nginx worker when reading user information from DB and therefore not recommended for real use.
+   This solution will block entire NGINX worker when reading user information from DB and therefore not recommended for real use.
 
    This solution is being used at at ISP with 35000+ mailboxes for almost 2 years now fine. If you want  shameful plug, the ISP is Worldsoft (http://www.worldsoft.info)
 
 Start with the configuration from :doc:`imapproxyexample`. For detail information about different configuration parameters, see the `ngx_mail_core_module <http://nginx.org/en/docs/mail/ngx_mail_core_module.html>`_ documentation.
 
-Configure nginx with embedded perl and mail
+Configure NGINX with embedded perl and mail
 
 .. code-block:: bash
 
@@ -64,7 +64,7 @@ Configure nginx with embedded perl and mail
       }
     }
 
-The ultrafast nginx based authentifier, ``nginx/perl/lib/mailauth.pm``:
+The ultrafast NGINX based authentifier, ``nginx/perl/lib/mailauth.pm``:
 
 .. code-block:: perl
 

--- a/source/start/topics/examples/imapauthenticatewithapachephpscript.rst
+++ b/source/start/topics/examples/imapauthenticatewithapachephpscript.rst
@@ -57,7 +57,7 @@ nginx.conf
 
   <?php
   /*
-  Nginx sends headers as
+  NGINX sends headers as
   Auth-User: somuser
   Auth-Pass: somepass
   On my php app server these are seen as
@@ -82,7 +82,7 @@ nginx.conf
     $backend_port=25;
   }
   
-  // nginx likes ip address so if your
+  // NGINX likes ip address so if your
   // application gives back hostname, convert it to ip address here
   $backend_ip["mailhost01"] ="192.168.1.22";
   $backend_ip["mailhost02"] ="192.168.1.33";

--- a/source/start/topics/examples/imapproxyexample.rst
+++ b/source/start/topics/examples/imapproxyexample.rst
@@ -73,7 +73,7 @@ To configure IMAP proxy with STARTTLS support, use nginx.conf like this:
 
   }
 
-.. note:: if you're using Nginx on linux, you need to run ``./configure`` with the mail options:
+.. note:: if you're using NGINX on linux, you need to run ``./configure`` with the mail options:
 
   .. code-block:: bash
   

--- a/source/start/topics/examples/initscripts.rst
+++ b/source/start/topics/examples/initscripts.rst
@@ -2,7 +2,7 @@
 .. meta::
    :description: Various useful init scripts for starting NGINX.
 
-Nginx Init Scripts
+NGINX Init Scripts
 ==================
 
 .. toctree::
@@ -17,7 +17,7 @@ Nginx Init Scripts
    freebsdspawnfcgi
    osxlaunchd
 
-So many way to start Nginx. You can either used the binary or set something up that will work specifically for your needs. If you install Nginx from a repository, then it is likely that you already have an init script installed. If you installed from source, then you'll want to find a script from below to help you out.
+So many way to start NGINX. You can either used the binary or set something up that will work specifically for your needs. If you install NGINX from a repository, then it is likely that you already have an init script installed. If you installed from source, then you'll want to find a script from below to help you out.
 
 Linux Init.d
 ------------
@@ -52,4 +52,4 @@ OSX
 Windows
 -------
 
-* :github:`Nginx Service for Windows <InvGate/winginx/>` which uses `NSSM <http://nssm.cc/>`_ as a wrapper for service behaviour.
+* :github:`NGINX Service for Windows <InvGate/winginx/>` which uses `NSSM <http://nssm.cc/>`_ as a wrapper for service behaviour.

--- a/source/start/topics/examples/javaservers.rst
+++ b/source/start/topics/examples/javaservers.rst
@@ -6,12 +6,12 @@ Java servers like Jetty, GlassFish and Tomcat
 =============================================
 
 You cannot deploy using .war files.
-The application files need to be deployed into a folder, because the Java web application folder must be specified for Nginx so that it can find and directly send static files like images (.jpg, .png, .gif), stylesheets (.css) and JavaScript (.js) directly.
-These files don't need to be processed by the Java server - just let Nginx do this job.
+The application files need to be deployed into a folder, because the Java web application folder must be specified for NGINX so that it can find and directly send static files like images (.jpg, .png, .gif), stylesheets (.css) and JavaScript (.js) directly.
+These files don't need to be processed by the Java server - just let NGINX do this job.
 
 For this sample we use Jetty, because it has the best performance.
 
-In the below example nginx works as a reverse proxy in the front of Java Servers.
+In the below example NGINX works as a reverse proxy in the front of Java Servers.
 
 
 
@@ -140,7 +140,7 @@ Server section configuration
 On the same server, protect the Java server from external access
 ----------------------------------------------------------------
 
-If you are running Nginx on the same server of the Java, the best practice is to deny access to port 8080 so only Nginx can access it. 
+If you are running NGINX on the same server of the Java, the best practice is to deny access to port 8080 so only NGINX can access it. 
 On Linux do
 
 .. code-block:: bash
@@ -169,7 +169,7 @@ Or on embedded Jetty server code:
   server.start();
   server.join();
 
-.. seealso:: To embed a java handler in nginx, check out :doc:`../../../modules/clojure`.
+.. seealso:: To embed a java handler in NGINX, check out :doc:`../../../modules/clojure`.
 
 .. todo::
    ..

--- a/source/start/topics/examples/likeapache-htaccess.rst
+++ b/source/start/topics/examples/likeapache-htaccess.rst
@@ -35,10 +35,10 @@ That's pretty typical.
 
 Now the numbers, that's 6 file system stats and 4 file system reads. 
 Including one for the requested file. This happens for every read. 
-We'll ignore parsing time because both Nginx and Apache need to do this and we'll consider the difference in time for this negligible.
+We'll ignore parsing time because both NGINX and Apache need to do this and we'll consider the difference in time for this negligible.
 
 +------------------+----------------+----------------+-----------------+-----------------+---------------------------------------------------------------------------------------------------------+
-| Requests / Hour  | Nginx FS Stats | Nginx FS Reads | Apache FD Stats | Apache FS Reads | Comment                                                                                                 |
+| Requests / Hour  | NGINX FS Stats | NGINX FS Reads | Apache FD Stats | Apache FS Reads | Comment                                                                                                 |
 +==================+================+================+=================+=================+=========================================================================================================+
 | 1                | 1              | 1              | 6               | 4               | Single Request&nbsp;&nbsp;[Pretty much no load]                                                         |
 +------------------+----------------+----------------+-----------------+-----------------+---------------------------------------------------------------------------------------------------------+
@@ -70,7 +70,7 @@ Two .htaccess files will be in this path unless you create your own.
 I'll be assuming you added one in /var/www/ because this is common.
 
 +-----------------+----------------+----------------+-----------------+-----------------+-------------+
-| Requests / Hour | Nginx FS Stats | Nginx FS Reads | Apache FD Stats | Apache FS Reads | Comment     |
+| Requests / Hour | NGINX FS Stats | NGINX FS Reads | Apache FD Stats | Apache FS Reads | Comment     |
 +=================+================+================+=================+=================+=============+
 | 144,000         | 144,000        | 144,000        | 1,296,000       | 576,000         | 40 req/sec  |
 +-----------------+----------------+----------------+-----------------+-----------------+-------------+
@@ -85,5 +85,5 @@ Conclusion
 ----------
 Stop using .htaccess. 
 It's horrible for performance. 
-Nginx is designed to be efficient. 
+NGINX is designed to be efficient. 
 Adding something like this destroys that.

--- a/source/start/topics/examples/likeapache.rst
+++ b/source/start/topics/examples/likeapache.rst
@@ -2,7 +2,7 @@
 .. meta::
    :description: How to set up an NGINX proxy that acts like Apache's ProxyPassReverse.
 
-Nginx Solution for Apache ProxyPassReverse
+NGINX Solution for Apache ProxyPassReverse
 ==========================================
 
 Apache 
@@ -19,13 +19,13 @@ Let's say we want to establish simple proxy between myhost:80 and myapp:8080. Th
   </VirtualHost>
 
 
-But Nginx does not have ProxyPassReverse... The solution is adding a few missing HTTP headers. 
+But NGINX does not have ProxyPassReverse... The solution is adding a few missing HTTP headers. 
 
 .. seealso:: `proxy_redirect <|HttpProxyModule|#proxy_redirect>`_. This wiki is partly incorrect. If you need to do location header rewriting, then you will need to use `proxy_redirect <|HttpProxyModule|#proxy_redirect>`_ as well.
 
 
 
-Nginx
+NGINX
 -----
 
 .. code-block:: nginx

--- a/source/start/topics/examples/logrotation.rst
+++ b/source/start/topics/examples/logrotation.rst
@@ -5,7 +5,7 @@
 Log Rotation
 ============
 
-Nginx will re-open its logs in response to the ``USR1`` signal.
+NGINX will re-open its logs in response to the ``USR1`` signal.
 
 .. code-block:: bash
 

--- a/source/start/topics/examples/memcachepreload.rst
+++ b/source/start/topics/examples/memcachepreload.rst
@@ -13,7 +13,7 @@ Ingredients
 
 #. serve the requests
 
-   * `nginx <http://nginx.org/en/docs/http/ngx_http_memcached_module.html>`_: webserver with memcache api
+   * `NGINX <http://nginx.org/en/docs/http/ngx_http_memcached_module.html>`_: webserver with memcache api
 
    * `couchbase <http://www.couchbase.com/nosql-databases/downloads>`_: persistent memcache server
 

--- a/source/start/topics/examples/mono.rst
+++ b/source/start/topics/examples/mono.rst
@@ -5,7 +5,7 @@
 Mono FCGI
 =========
 
-You want to run .NET websites behind Nginx and don't want to use Windows to do it. Spiffy.
+You want to run .NET websites behind NGINX and don't want to use Windows to do it. Spiffy.
 
 Here's the virtual host configuration you'll want.
 

--- a/source/start/topics/examples/nonrootwebpath.rst
+++ b/source/start/topics/examples/nonrootwebpath.rst
@@ -7,7 +7,7 @@ Non-root Web Path
 
 When installing FastCGI applications in non-root web path (for example, ``http://example.com/thisapp/``), some of them expect (and find sufficient) couple fastcgi parameters to be present: ``PATH_INFO`` and ``SCRIPT_NAME``, set in a similar way to how Apache sets them.
 
-So, what in Apache looks like ``FastCgiExternalServer /var/www/thisapp -socket /path/to/thisappfcgi.sock``, in nginx can be done this way:
+So, what in Apache looks like ``FastCgiExternalServer /var/www/thisapp -socket /path/to/thisappfcgi.sock``, in NGINX can be done this way:
 
 .. code-block:: nginx
 

--- a/source/start/topics/examples/osxlaunchd.rst
+++ b/source/start/topics/examples/osxlaunchd.rst
@@ -29,5 +29,5 @@ You will want to place this in ``/System/Library/LaunchDaemons/nginx.plist``, an
 
    launchctl load -F /System/Library/LaunchDaemons/nginx.plist
 
-after which it should behave correctly. Of course, the corresponding unload command is simply "unload", with or without the -F. Note that this launches nginx on boot, rather than when you choose it to. It also tells it to log stderr to syslog, which may not be to your preference (nginx likes to log to /usr/local/log/nginx.err).
+after which it should behave correctly. Of course, the corresponding unload command is simply "unload", with or without the -F. Note that this launches NGINX on boot, rather than when you choose it to. It also tells it to log stderr to syslog, which may not be to your preference (NGINX likes to log to /usr/local/log/nginx.err).
 

--- a/source/start/topics/examples/phpfastcgionwindows.rst
+++ b/source/start/topics/examples/phpfastcgionwindows.rst
@@ -7,8 +7,8 @@ PHP-FastCGI on Windows
 
 Overview
 --------
-Nginx can interface with PHP on Windows via a FastCGI daemon, which ships with PHP: php-cgi.exe. 
-You need to run ``php-cgi.exe -b 127.0.0.1:<port>`` and use ``fastcgi_fastcgi_pass_ 127.0.0.1:<port>;`` in the nginx configuration file. 
+NGINX can interface with PHP on Windows via a FastCGI daemon, which ships with PHP: php-cgi.exe. 
+You need to run ``php-cgi.exe -b 127.0.0.1:<port>`` and use ``fastcgi_fastcgi_pass_ 127.0.0.1:<port>;`` in the NGINX configuration file. 
 After being launched, ``php-cgi.exe`` will keep listening for connections in a command prompt window. 
 To hide that window, use the tiny utility `RunHiddenConsole <http://redmine.lighttpd.net/attachments/660/RunHiddenConsole.zip>`_ 
 
@@ -20,7 +20,7 @@ To hide that window, use the tiny utility `RunHiddenConsole <http://redmine.ligh
 
 Steps
 -----
-#. Install `Nginx for Win32 <install_win32_binaries_>_`.
+#. Install `NGINX for Win32 <install_win32_binaries_>_`.
 #. Install the `Windows binaries of PHP <http://windows.php.net/>`_, making sure that ``php-cgi.exe`` is installed in the same directory as ``php.exe``.
 #. Create somewhere (e.g. in ``c:\nginx\``) a batch file ``start-php-fcgi.bat`` similar to this one:
 
@@ -48,11 +48,11 @@ Steps
 
 
 
-Autostarting PHP and Nginx
+Autostarting PHP and NGINX
 --------------------------
 #. Schedule a basic (on Windows Vista) task to run the batch file above at system start up under the SYSTEM account. 
-#. If using Windows Nginx from http://kevinworthington.com/nginx-for-windows/, schedule a basic (on Windows Vista) task to run ``C:\nginx\conf\start-nginx.bat`` file at system start up under the SYSTEM account in starting directory ``C:\nginx``. 
-#. A home made Cygwin build of Nginx can be scheduled using a batch file similar to this:
+#. If using Windows NGINX from http://kevinworthington.com/nginx-for-windows/, schedule a basic (on Windows Vista) task to run ``C:\nginx\conf\start-nginx.bat`` file at system start up under the SYSTEM account in starting directory ``C:\nginx``. 
+#. A home made Cygwin build of NGINX can be scheduled using a batch file similar to this:
 
   .. code-block:: bash
     

--- a/source/start/topics/examples/phpfcgi.rst
+++ b/source/start/topics/examples/phpfcgi.rst
@@ -9,7 +9,7 @@ This example is for newer PHP (>= 5.3.3) using the included PHP FPM (FastCGI Pro
 
 This guide assume PHP FPM already installed and configured either using tcp port (``127.0.0.1:9000``) or unix socket (``/var/run/php-fpm.sock``).
 
-There are many guide about configuring nginx with PHP FPM,
+There are many guide about configuring NGINX with PHP FPM,
 but many of them are incomplete (*doesn't handle PATH_INFO correctly*)
 or contain security issues (*doesn't check whether the script is indeed php file*).
 
@@ -52,10 +52,10 @@ For example on debian and ubuntu by default there is ``/etc/nginx/fastcgi_params
 
 Please note if you're using Ubuntu Precise (12.04), I change ``SCRIPT_FILENAME`` and add ``PATH_INFO`` params.
 
-Connecting nginx to PHP FPM
+Connecting NGINX to PHP FPM
 ---------------------------
 
-Now we must tell Nginx to proxy requests to PHP FPM via the FCGI protocol:
+Now we must tell NGINX to proxy requests to PHP FPM via the FCGI protocol:
 
 .. code-block:: nginx
 
@@ -76,12 +76,12 @@ If you're using unix socket change ``fastcgi_pass`` to:
 
     fastcgi_pass unix:/var/run/php5-fpm.sock;
 
-Restart nginx.
+Restart NGINX.
 
 Testing
 -------
 
-Create ``test.php`` on nginx document root containing just:
+Create ``test.php`` on NGINX document root containing just:
 
 .. code-block:: php
 
@@ -137,10 +137,10 @@ Notes
 
 #. The location regex capable to handle ``PATH_INFO`` and properly check that the extension indeed .php (not .phps) whether there is PATH_INFO or not.
 #. The ``fastcgi_split_path_info`` regex capable to correctly handle request like ``/test.php/foo/blah.php`` or ``/test.php/``.
-#. The ``if`` lets nginx check whether the ``*.php`` does indeed exist to prevent nginx to feeding PHP FPM non php script file (like uploaded image).
+#. The ``if`` lets NGINX check whether the ``*.php`` does indeed exist to prevent NGINX to feeding PHP FPM non php script file (like uploaded image).
 
 Some guides recommend to use ``try_files`` instead of ``if``,
-if you do that, beware of nginx `bug #321 <https://trac.nginx.org/nginx/ticket/321>`_.
+if you do that, beware of NGINX `bug #321 <https://trac.nginx.org/nginx/ticket/321>`_.
 I personally think ``if`` is more appropriate for this, even :doc:`../depth/ifisevil` agree this is one of the 100% safe thing to use ``if`` with.
 
 This guide run fine on php.ini ``cgi.fix_pathinfo = 1`` (the default).

--- a/source/start/topics/examples/redhatnginxinit.rst
+++ b/source/start/topics/examples/redhatnginxinit.rst
@@ -2,7 +2,7 @@
 .. meta::
    :description: An example NGINX init script that works on Red Hat systems.
 
-Red Hat Nginx Init Script
+Red Hat NGINX Init Script
 =========================
 
 Should work on RHEL, Fedora, CentOS.   Tested on CentOS 5.
@@ -16,7 +16,7 @@ Save this file as ``/etc/init.d/nginx``
     # nginx - this script starts and stops the nginx daemon
     #
     # chkconfig:   - 85 15 
-    # description:  Nginx is an HTTP(S) server, HTTP(S) reverse \
+    # description:  NGINX is an HTTP(S) server, HTTP(S) reverse \
     #               proxy and IMAP/POP3 proxy server
     # processname: nginx
     # config:      /etc/nginx/nginx.conf

--- a/source/start/topics/examples/server_blocks.rst
+++ b/source/start/topics/examples/server_blocks.rst
@@ -5,7 +5,7 @@
 Server Block Examples
 =====================
 
-Note: "VirtualHost" is an Apache term. Nginx does not have Virtual hosts, it has "Server Blocks" that use the server_name and listen directives to bind to tcp sockets.
+Note: "VirtualHost" is an Apache term. NGINX does not have Virtual hosts, it has "Server Blocks" that use the server_name and listen directives to bind to tcp sockets.
 
 Two Server Blocks, Serving Static Files
 ---------------------------------------

--- a/source/start/topics/examples/simplecgi.rst
+++ b/source/start/topics/examples/simplecgi.rst
@@ -5,9 +5,9 @@
 Simple CGI
 ==========
 
-For the most part, lack of CGI support in Nginx is not an issue and actually has an important side-benefit: because Nginx cannot directly execute external programs (CGI), a malicious person can't trick your system into uploading and executing an arbitrary script.
+For the most part, lack of CGI support in NGINX is not an issue and actually has an important side-benefit: because NGINX cannot directly execute external programs (CGI), a malicious person can't trick your system into uploading and executing an arbitrary script.
 There are still ways, of course (uploading a PHP script into a directory where you've got a directive to execute PHP FastCGI scripts for example), but it does in fact make it a bit more difficult (or conversely, easier to secure).
-Still, sometimes you have a one-off simple CGI program you need to support and here's a recipe for exposing your CGI to Nginx as a FastCGI instead:
+Still, sometimes you have a one-off simple CGI program you need to support and here's a recipe for exposing your CGI to NGINX as a FastCGI instead:
 
 Let's say this is our CGI program, written in Perl:
 
@@ -187,10 +187,10 @@ Next, we need a Perl wrapper that will run as a FastCGI and run this for us:
 Save the above script as ``/usr/local/bin/cgiwrap-fcgi.pl``.
 
 Just running the program as above will bind it to a unix socket at ``/var/run/nginx/cgiwrap-dispatch.sock``. 
-Be sure your nginx worker process user has read/write access to this file.
+Be sure your NGINX worker process user has read/write access to this file.
 The script does not fork itself, so you will need to background it somehow (with Bash add an ampersand "&" at the end of your command to execute it).
 
-If this all works, then the next part is to setup Nginx:
+If this all works, then the next part is to setup NGINX:
 
 .. code-block:: nginx
 
@@ -221,7 +221,7 @@ If this all works, then the next part is to setup Nginx:
     }
   }
 
-Restart Nginx and point your browser at your CGI program. 
+Restart NGINX and point your browser at your CGI program. 
 The above sample config will execute any .cgi file in ``cgi-bin`` with the ``cgiwrap-fcgi.pl`` wrapper, tweak this to your heart's content.
 
 I've been able to run Python, Perl, and C++ cgi apps with this - apps that use GET or POST.

--- a/source/start/topics/examples/simplepythonfcgi.rst
+++ b/source/start/topics/examples/simplepythonfcgi.rst
@@ -8,13 +8,13 @@ Dispatching TurboGears Python via FCGI
 This confirmed to run on Mac OS X 10.4.7 under Turbogears 0.9.9 and 1.1a (so, no reason not to run under the 1.0b release).
 
 
-Information was drawn from the Turbogears trac wiki which shows how to use Nginx to proxy to TG, and the nearby :doc:`fastcgiexample`  page, the latter detailing the PHP/FCGI process.
+Information was drawn from the Turbogears trac wiki which shows how to use NGINX to proxy to TG, and the nearby :doc:`fastcgiexample`  page, the latter detailing the PHP/FCGI process.
 
 .. 
    Dead link
    `Turbogears trac wiki <http://trac.turbogears.org/turbogears/wiki/NginxIntegration>`_
    
-This is for Nginx/FCGI/Turbogears
+This is for NGINX/FCGI/Turbogears
 
 
 
@@ -24,7 +24,7 @@ Substitute thoughout with the values relevant to your own set-up:
 
 - ``${HOST} = localhost`` - (or whatever you choose)
 - ``${PORT} = 8080`` - (or whatever you choose)
-- ``${NGINX} = /usr/local/nginx`` - location of nginx installation
+- ``${NGINX} = /usr/local/nginx`` - location of NGINX installation
 - ``${PROJECTBASE} /opt/projects/wiki20`` - location of Turbogears project
 - ``${PROJECTNAME} wiki20``
 
@@ -195,7 +195,7 @@ Then (replacing ``${HOST}`` and ``${PORT}`` values appropriately), execute the f
 
 
 
-Nginx configuration
+NGINX configuration
 -------------------
 Save the following into ``${NGINX}/conf/fastcgi_params``
 
@@ -246,9 +246,9 @@ Add the following to the server section of the ``${NGINX}/conf/nginx.conf`` conf
  
 
 
-Starting Nginx
+Starting NGINX
 --------------
-Start nginx with ``${NGINX}/sbin/nginx``. 
+Start NGINX with ``${NGINX}/sbin/nginx``. 
 Point your browser to ``http://${HOST}:${PORT}/``, your Turboears project should be serving via FastCGI. 
 If so... congratulations.
 

--- a/source/start/topics/examples/systemd.rst
+++ b/source/start/topics/examples/systemd.rst
@@ -2,19 +2,19 @@
 .. meta::
    :description: An example of a simple NGINX systemd service file.
 
-Nginx systemd service file
+NGINX systemd service file
 ==========================
 
 Should work on Fedora, OpenSUSE, Arch Linux. Tested on Fedora 16 and 17.
 
-The location of the PIDFile and the nginx binary may be different depending on how nginx was compiled.
+The location of the PIDFile and the NGINX binary may be different depending on how NGINX was compiled.
 
 Save this file as ``/lib/systemd/system/nginx.service``
 
 .. code-block:: ini
 
     [Unit]
-    Description=The nginx HTTP and reverse proxy server
+    Description=The NGINX HTTP and reverse proxy server
     After=syslog.target network.target remote-fs.target nss-lookup.target
 
     [Service]

--- a/source/start/topics/examples/ubuntuupstart.rst
+++ b/source/start/topics/examples/ubuntuupstart.rst
@@ -34,7 +34,7 @@ Save this file as ``/etc/init/nginx.conf``
 
    exec $DAEMON
 
-``respawn`` tells upstart to keep nginx master process alive and expect fork tracks ngnix after the fork. pre-start script helps say when the services fails
+``respawn`` tells upstart to keep NGINX master process alive and expect fork tracks ngnix after the fork. pre-start script helps say when the services fails
 
 ``respawn limit`` tells that if the process is respawned more than 10 times within an interval of 5 seconds, the process will be stopped automatically, and not restarted (the default upstart value).
 

--- a/source/start/topics/examples/x-accel.rst
+++ b/source/start/topics/examples/x-accel.rst
@@ -9,12 +9,12 @@ Synopsis
 --------
 X-accel allows for internal redirection to a location determined by a header returned from a backend.
 
-This allows you to handle authentication, logging or whatever else you please in your backend and then have Nginx handle serving the contents from redirected location to the end user, thus freeing up the backend to handle other requests.
+This allows you to handle authentication, logging or whatever else you please in your backend and then have NGINX handle serving the contents from redirected location to the end user, thus freeing up the backend to handle other requests.
 This feature is commonly known as X-Sendfile.
 
-This feature differs a bit from standard Nginx modules as it does not rely on directives but rather handles headers from upstream in a special way.
+This feature differs a bit from standard NGINX modules as it does not rely on directives but rather handles headers from upstream in a special way.
 The way it works is that you send the header `x-accel.redirect`_ with a URI.
-Nginx will match this URI against its locations as if it was a normal request.
+NGINX will match this URI against its locations as if it was a normal request.
 It will then serve the location that matches the defined root + URI passed in the header.
 
 Example configuration, notice the difference between alias and root.
@@ -56,7 +56,7 @@ X-Accel-Redirect
 :Syntax: *X-Accel-Redirect uri*
 :Default: *X-Accel-Redirect void*
 
-Sets the URI for Nginx to serve.
+Sets the URI for NGINX to serve.
 
 
 X-Accel-Buffering
@@ -82,7 +82,7 @@ X-Accel-Expires
 :Syntax: *X-Accel-Expires [off|seconds]*
 :Default: *X-Accel-Expires off*
 
-Sets when to expire the file in the internal Nginx cache, if one is used.
+Sets when to expire the file in the internal NGINX cache, if one is used.
 
 
 X-Accel-Limit-Rate

--- a/source/start/topics/examples/xsendfile.rst
+++ b/source/start/topics/examples/xsendfile.rst
@@ -11,14 +11,14 @@ The delivery of a static file which depends on an application header is known as
 
 `Lighttpd <http://www.lighttpd.net>`_  has this feature and there is a `mod_xsendfile <https://tn123.org/mod_xsendfile/>`_ for Apache2.
 
-Nginx also has this feature, but implemented a little bit differently. In Nginx this feature is called ``X-Accel-Redirect``.
+NGINX also has this feature, but implemented a little bit differently. In NGINX this feature is called ``X-Accel-Redirect``.
 
 There are two main differences:
 
 #. The header must contain a ``URI``.
 #. The location ``should`` be defined as ``internal;`` to prevent the client from going directly to the URI.
 
-Example nginx configuration:
+Example NGINX configuration:
 
 .. code-block:: nginx
 
@@ -33,9 +33,9 @@ If the application adds an header X-Accel-Redirect for the location ``/protected
 
    X-Accel-Redirect: /protected/iso.img;
 
-Then nginx will serve the file ``/some/path/protected/iso.img`` - note that the root and internal redirect paths are concatenated.
+Then NGINX will serve the file ``/some/path/protected/iso.img`` - note that the root and internal redirect paths are concatenated.
 
-If you want to deliver ``/some/path/iso.img`` then configure nginx like this:
+If you want to deliver ``/some/path/iso.img`` then configure NGINX like this:
 
 .. code-block:: nginx
 
@@ -44,7 +44,7 @@ If you want to deliver ``/some/path/iso.img`` then configure nginx like this:
       alias   /some/path/; # note the trailing slash
     }
 
-Note that the following HTTP headers aren't ``modified`` by nginx::
+Note that the following HTTP headers aren't ``modified`` by NGINX::
 
     Content-Type
     Content-Disposition
@@ -65,7 +65,7 @@ The application can also have some control over the process, sending the followi
 
 Links to this issue
 -------------------
-* `Using X-Accel-Redirect Header With Nginx to Implement Controlled Downloads (with rails and php examples) <http://kovyrin.net/2006/11/01/nginx-x-accel-redirect-php-rails/>`_ from `Alexey Kovyrin <http://kovyrin.net/>`_
+* `Using X-Accel-Redirect Header With NGINX to Implement Controlled Downloads (with rails and php examples) <http://kovyrin.net/2006/11/01/nginx-x-accel-redirect-php-rails/>`_ from `Alexey Kovyrin <http://kovyrin.net/>`_
 
 * `Nginx-Fu: X-Accel-Redirect From Remote Servers <http://kovyrin.net/2010/07/24/nginx-fu-x-accel-redirect-remote/>`_ from `Alexey Kovyrin <http://kovyrin.net/>`_
 

--- a/source/start/topics/recipes/mailman.rst
+++ b/source/start/topics/recipes/mailman.rst
@@ -16,7 +16,7 @@ digest delivery, spam filters, and more.
 Mailman is crazy. This page used to focus on giving you options to install,
 configure, and run it as you wish. Because of the crazy that is mailman, this
 will show you the most common and best supported way to set up Mailman
-software behind Nginx.
+software behind NGINX.
 
 The Recipe
 ----------
@@ -98,7 +98,7 @@ Fix Authentication
 
 If you end up running into an issue where you have to authenticate for every
 link clicked in the admin interface, you may have changed the URI. This would
-happen if you are migrating from Apache or something else to Nginx. You can
+happen if you are migrating from Apache or something else to NGINX. You can
 either try to match what you were using previously by manipulating the location
 blocks and thttpd config so the /mailman or the /cgi-bin/mailman will be passed
 to mailman. The other option is to run the command below.

--- a/source/start/topics/recipes/mediawiki.rst
+++ b/source/start/topics/recipes/mediawiki.rst
@@ -13,7 +13,7 @@ Requirements
 Recipe
 ------
 
-Here's the basic configuration used for the Nginx wiki.
+Here's the basic configuration used for the NGINX wiki.
 
 .. code-block:: nginx
 

--- a/source/start/topics/recipes/mybb.rst
+++ b/source/start/topics/recipes/mybb.rst
@@ -38,7 +38,7 @@ Recipe
 
     }
 
-There is a potential security flaw, e.g. if a user uploads an avatar images pic.gif with valid PHP-Code and calls it with /uploades/avatars/pic.gif/foo.php. The issue is discussed `here <pitfalls.uncontrollable_requests_to_php_>`. Because the link is ending with .php, nginx is passing it to the PHP interpreter. PHP can't find the file /uploades/avatars/pic.gif/foo.php, but it tries to be smart and executes /uploades/avatars/pic.gif as an PHP-script. To avoid this, you need to set cgi.fix_pathinfo=0 in your php.ini, which is set to cgi.fix_pathinfo=1 as default (unfortunately).
+There is a potential security flaw, e.g. if a user uploads an avatar images pic.gif with valid PHP-Code and calls it with /uploades/avatars/pic.gif/foo.php. The issue is discussed `here <pitfalls.uncontrollable_requests_to_php_>`. Because the link is ending with .php, NGINX is passing it to the PHP interpreter. PHP can't find the file /uploades/avatars/pic.gif/foo.php, but it tries to be smart and executes /uploades/avatars/pic.gif as an PHP-script. To avoid this, you need to set cgi.fix_pathinfo=0 in your php.ini, which is set to cgi.fix_pathinfo=1 as default (unfortunately).
 
 See :doc:`../examples/phpfcgi` for details on creating the UNIX socket and `this forum post <http://community.mybb.com/thread-51764.html>`_ on enabling human-understandable (aka SEO-friendly or human-readable) URLs using the Google SEO plugin.
 

--- a/source/start/topics/recipes/qwebirc.rst
+++ b/source/start/topics/recipes/qwebirc.rst
@@ -5,7 +5,7 @@
 Qwebric
 =======
 
-`Qwebirc <https://qwebirc.org/>`_ is a fast, easy to use, free and open source IRC client designed by and originally just for the `QuakeNet IRC network <https://www.quakenet.org/>`_. Released in 2009, it's a `python <https://www.python.org>`_ written web-based IRC client. It also has a fork, `iris <http://www.atheme.net/iris.html>`_, developed by the `Atheme <http://www.atheme.net/>`_ IRC services team, and provides better integration with Atheme's IRC services. Qwebirc uses its own embedded webserver utilizing non-blocking multiplexing, and can cope with thousands of users easily. Because of this, there are two methods which can be used to direct clients to a qwebirc instance via `nginx <http://nginx.org>`_: redirection, or reverse proxy.
+`Qwebirc <https://qwebirc.org/>`_ is a fast, easy to use, free and open source IRC client designed by and originally just for the `QuakeNet IRC network <https://www.quakenet.org/>`_. Released in 2009, it's a `python <https://www.python.org>`_ written web-based IRC client. It also has a fork, `iris <http://www.atheme.net/iris.html>`_, developed by the `Atheme <http://www.atheme.net/>`_ IRC services team, and provides better integration with Atheme's IRC services. Qwebirc uses its own embedded webserver utilizing non-blocking multiplexing, and can cope with thousands of users easily. Because of this, there are two methods which can be used to direct clients to a qwebirc instance via `NGINX <http://nginx.org>`_: redirection, or reverse proxy.
 
 Recipe
 ------
@@ -29,7 +29,7 @@ This would take any requests for webchat.domain.tld, and redirect it to webchat.
 Reserve Proxy Method
 ^^^^^^^^^^^^^^^^^^^^
 
-It is also possible to reverse proxy qwebirc from nginx, hiding the port number in the address bar, and using nginx as the frontend. To do this, you would first set up a server block to look like:
+It is also possible to reverse proxy qwebirc from NGINX, hiding the port number in the address bar, and using NGINX as the frontend. To do this, you would first set up a server block to look like:
 
 .. code-block:: nginx
 

--- a/source/start/topics/recipes/redmine.rst
+++ b/source/start/topics/recipes/redmine.rst
@@ -5,7 +5,7 @@
 Redmine
 =======
 
-Redmine is seemingly complex. It is. However, when it comes to Nginx, it isn't.
+Redmine is seemingly complex. It is. However, when it comes to NGINX, it isn't.
 
 Recipe
 ------

--- a/source/start/topics/recipes/silverstripe.rst
+++ b/source/start/topics/recipes/silverstripe.rst
@@ -5,7 +5,7 @@
 SilverStripe
 ============
 
-`SilverStripe <http://www.silverstripe.org/>`_ is a modern PHP based CMS Framework that runs happily on nginx.  
+`SilverStripe <http://www.silverstripe.org/>`_ is a modern PHP based CMS Framework that runs happily on NGINX.  
   
 There are several built in failsafes that will attempt to rectify any errors in rewrite rules.  
 First, SS relies on an ``.htaccess`` file to define how to handle URLs.  

--- a/source/start/topics/recipes/symfony.rst
+++ b/source/start/topics/recipes/symfony.rst
@@ -181,7 +181,7 @@ Another working symfony
         include        fastcgi_params;
     }
 
-Using Nginx as a development server for symphony, this is a php (cli) script which configurate and launch Nginx in a directory, the result is similar to django development server.
+Using NGINX as a development server for symphony, this is a php (cli) script which configurate and launch NGINX in a directory, the result is similar to django development server.
 
 .. code-block:: php
 
@@ -259,7 +259,7 @@ Using Nginx as a development server for symphony, this is a php (cli) script whi
 
     echo passthru('nginx -c /tmp'.getcwd().'/nginx.conf -t', $return_var);
     assert ('0 == $return_var');
-    usleep(200000); echo "Launching Nginx\n";
+    usleep(200000); echo "Launching NGINX\n";
     // echo passthru('nginx -c /tmp'.getcwd().'/nginx.conf', $return_var);
     // assert ('0 == $return_var');
 
@@ -274,7 +274,7 @@ Using Nginx as a development server for symphony, this is a php (cli) script whi
     pcntl_sigwaitinfo(array(SIGHUP, SIGINT, SIGUSR1));
     pcntl_sigprocmask(SIG_SETMASK, $oldset);
 
-    echo "\nShutting doen Nginx\n";
+    echo "\nShutting doen NGINX\n";
     echo passthru('nginx -c /tmp'.getcwd().'/nginx.conf -s stop', $return_var);
     assert ('0 == $return_var');
 

--- a/source/start/topics/recipes/wordpress.rst
+++ b/source/start/topics/recipes/wordpress.rst
@@ -5,7 +5,7 @@
 WordPress
 =========
 
-`Nginx <http://nginx.org>`_ works perfectly well with a wide variety of applications, and `WordPress <https://wordpress.org>`_ is certainly one of them.  Nginx's configuration language is very powerful and straightforward if one is familiar with it, but often people coming from other servers are not sure how things work in Nginx and just copy and paste whatever they see from a blog that seems to fill their needs.  Everyone, especially people new to Nginx, should check out the `nginx.org documentation <http://nginx.org/en/docs/>`_ for an overview of how things work and should be done in Nginx.
+`NGINX <http://nginx.org>`_ works perfectly well with a wide variety of applications, and `WordPress <https://wordpress.org>`_ is certainly one of them.  NGINX's configuration language is very powerful and straightforward if one is familiar with it, but often people coming from other servers are not sure how things work in NGINX and just copy and paste whatever they see from a blog that seems to fill their needs.  Everyone, especially people new to NGINX, should check out the `nginx.org documentation <http://nginx.org/en/docs/>`_ for an overview of how things work and should be done in NGINX.
 
 Recipe
 ------
@@ -13,7 +13,7 @@ Recipe
 Abridged basic setup
 ^^^^^^^^^^^^^^^^^^^^
 
-Hopefully you have read the documentation above and maybe worked on setting up a virtual server or two in Nginx already - if not there are a few notes below, but you should still read the documentation.
+Hopefully you have read the documentation above and maybe worked on setting up a virtual server or two in NGINX already - if not there are a few notes below, but you should still read the documentation.
 
 First we setup a named upstream for our php, which allows us to abstract the backend and easily change the port or add more backends. After that, we setup our virtual host configuration for domain.tld.
 
@@ -100,7 +100,7 @@ Rewrite rules for Multisite
 
 `WordPress Multisite <http://codex.wordpress.org/Create_A_Network>`_ can be used in multiple ways. Most notably "subdirectories" mode and "subdomains" mode. 
 
-Nginx provides 2 special directive: `X-Accel-Redirect <x-accel.redirect_>` and `map <http://nginx.org/en/docs/http/ngx_http_map_module.html#map>`_. Using these 2 directives, one can eliminate performance hit for static-file serving on WordPress multisite network.
+NGINX provides 2 special directive: `X-Accel-Redirect <x-accel.redirect_>` and `map <http://nginx.org/en/docs/http/ngx_http_map_module.html#map>`_. Using these 2 directives, one can eliminate performance hit for static-file serving on WordPress multisite network.
 
 Rewrite rules for Multisite using subdirectories
 """"""""""""""""""""""""""""""""""""""""""""""""
@@ -204,6 +204,6 @@ Rewrite rules for Multisite using subdomains
 
     * For wordpress-nginx based sites management, `EasyEngine <https://github.com/rtCamp/easyengine>`_ can be used. EasyEngine is collection of shell scripts for Ubuntu.
     * map section can be completed manually for small sites. On large multisite network `nginx-helper <https://wordpress.org/plugins/nginx-helper/>`_ wordpress plugin can be used.
-    * Further performance gain is possible by using Nginx's fastcgi_cache. When using `fastcgi_cache <http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_cache>`_, compile nginx with `ngx_cache_purge <https://github.com/FRiCKLE/ngx_cache_purge>`_ module and add a wordpress-plugin which performs automatic cache purge on events e.g. a wordpress post/page is edited.
-    * `Nginx Cache Controller <https://wordpress.org/plugins/nginx-champuru/>`_ WordPress plugin provides some functions of controlling Nginx proxy server cache.
-    * `Nginx Mobile Theme <https://wordpress.org/plugins/nginx-mobile-theme/>`_ WordPress plugin allows you to switch theme according to the User Agent on the Nginx reverse proxy.
+    * Further performance gain is possible by using NGINX's fastcgi_cache. When using `fastcgi_cache <http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_cache>`_, compile NGINX with `ngx_cache_purge <https://github.com/FRiCKLE/ngx_cache_purge>`_ module and add a wordpress-plugin which performs automatic cache purge on events e.g. a wordpress post/page is edited.
+    * `NGINX Cache Controller <https://wordpress.org/plugins/nginx-champuru/>`_ WordPress plugin provides some functions of controlling NGINX proxy server cache.
+    * `NGINX Mobile Theme <https://wordpress.org/plugins/nginx-mobile-theme/>`_ WordPress plugin allows you to switch theme according to the User Agent on the NGINX reverse proxy.

--- a/source/start/topics/recipes/yii.rst
+++ b/source/start/topics/recipes/yii.rst
@@ -11,7 +11,7 @@ Recipe
 This configuring gives SEF URLs for Yii
 
 
-Nginx configuration
+NGINX configuration
 ^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: nginx

--- a/source/start/topics/recipes/zend.rst
+++ b/source/start/topics/recipes/zend.rst
@@ -16,19 +16,19 @@ Follow the `installation instructions on their website <http://framework.zend.co
     Optionally, you can add the path to the library/ subdirectory of the archive to your php.ini's include_path setting.
     That's it! Zend Framework is now installed and ready to use.
 
-If that is your preference, you can stop reading now and read-up on how to configure ``nginx`` to work directly with :doc:`PHP FastCGI <../examples/phpfcgi>`
+If that is your preference, you can stop reading now and read-up on how to configure NGINX to work directly with :doc:`PHP FastCGI <../examples/phpfcgi>`
 
 Alternatively, Zend Framework also comes packaged with both, the free and paid-for edition of `Zend Server <http://www.zend.com/en/products/server/editions>`_:
 
     Zend Server includes a production-ready, tested stack that incorporates PHP, Zend Framework, required extensions and drivers - all installed through RPM/DEB on Linux or MSI on Windows. Zend Server also support IBM i.
 
-In the rest of this guide I am covering the integration of ``nginx`` with Zend Server Free Edition for PHP Version 5.3. My installation is on Ubuntu 10.10 Maverick Meerkat, but it should work on yours just as well. Detailed installation instructions for all supported platforms are at http://files.zend.com/help/Zend-Server-6/zend-server.htm#installation_guide.htm
+In the rest of this guide I am covering the integration of NGINX with Zend Server Free Edition for PHP Version 5.3. My installation is on Ubuntu 10.10 Maverick Meerkat, but it should work on yours just as well. Detailed installation instructions for all supported platforms are at http://files.zend.com/help/Zend-Server-6/zend-server.htm#installation_guide.htm
 
 A few of my observations for your consideration
 -----------------------------------------------
 
-* beginning with Zend Server 6.1, nginx is nativly suported by Zend Server
-* in a non-nginx setup, the Zend Server includes both, Apache 2.2 for serving your actual PHP application, and lighthttp for the Zend Server Administration GUI
+* beginning with Zend Server 6.1, NGINX is nativly suported by Zend Server
+* in a non-NGINX setup, the Zend Server includes both, Apache 2.2 for serving your actual PHP application, and lighthttp for the Zend Server Administration GUI
 * the number of additional packages and files from Zend are rather heavy-weight; you not only get PHP 5.3 (5.4 is also supported) but also the Zend Framework, Apache 2.2 and the Zend Server Administration GUI
 * also, once you install Zend Server, your "native" PHP installation packages from your distro will be removed, since those are obsolete now
 * on the upside, Zend provides repositories for Redhat/CentOS as well as Debian/Ubuntu, hence whenever you update your system, the Zend Server packages including your Zend Framework will be updated  with your regular update process, e.g. ``aptitude full-upgrade`` or ``yum update``. That is really nice, especially if you are using something like ``apticron``. No more out-dated PHP or Zend Framework libraries. Nice!
@@ -39,7 +39,7 @@ Allright, with no further ado, here we go ...
 Automated installation instructions
 -----------------------------------
 
-Starting with Zend Server 6.1 you can use an automated installation script to install nginx & Zend Server.
+Starting with Zend Server 6.1 you can use an automated installation script to install NGINX & Zend Server.
 
 #. Download the package called "Zend Server (DEB/RPM Installer Script)" from zend.com - http://www.zend.com/en/products/server/downloads
 
@@ -70,7 +70,7 @@ The following commands install the Zend Server Free Edition and stop both, the A
     sudo aptitude install zend-server-php-5.3
     sudo service zend-server stop
 
-Once that is done, you want to create a custom php-fastcgi script for ``Zend Server Free Edition`` that ``nginx`` can use to forward PHP template processing to, just as you would do for a regular PHP installation. 
+Once that is done, you want to create a custom php-fastcgi script for ``Zend Server Free Edition`` that NGINX can use to forward PHP template processing to, just as you would do for a regular PHP installation. 
 
 Create the file ``/etc/init.d/php-fastcgi`` as root and put the following content in it:
 
@@ -78,7 +78,7 @@ Create the file ``/etc/init.d/php-fastcgi`` as root and put the following conten
 
     #!/bin/bash
     # Inspired from /usr/local/zend/bin/lighttpdctl.sh
-    # Zend GUI uses lighttpd and fastcgi - we want the same for nginx
+    # Zend GUI uses lighttpd and fastcgi - we want the same for NGINX
     # its all about the unix socket - if on the same machine
     # otherwise bind to address and port; this is similar to the "regular" php-fastcgi
 
@@ -132,7 +132,7 @@ Create the file ``/etc/init.d/php-fastcgi`` as root and put the following conten
 
     exit $?
 
-You notice, we are lifting various settings from the Zend installation (/etc/zce.rc) that will have some impact on the configuration of ``nginx``. Particularly, I decided to use Unix sockets for performance reasons since I am on the same machine with both, ``nginx`` and the ``Zend Server and Framework``. The rest of the file is heavily inspired by the start and stop scripts for the built-in Zend GUI (based on lighttpd) which also uses spawn-cgi!!
+You notice, we are lifting various settings from the Zend installation (/etc/zce.rc) that will have some impact on the configuration of NGINX. Particularly, I decided to use Unix sockets for performance reasons since I am on the same machine with both, NGINX and the ``Zend Server and Framework``. The rest of the file is heavily inspired by the start and stop scripts for the built-in Zend GUI (based on lighttpd) which also uses spawn-cgi!!
 
 Next up, make the file executable and add it to your servers regular environment for controlling system daemons:
 
@@ -150,10 +150,10 @@ In order to avoid port conflicts and save system resources, and of course we do 
     cd /etc/init.d
     sudo update-rc.d -f zend-server remove
 
-Time for nginx
+Time for NGINX
 --------------
 
-Now, all that is left is to configure ``nginx`` to forward all PHP requests to our newly installed ``Zend Server``
+Now, all that is left is to configure NGINX to forward all PHP requests to our newly installed ``Zend Server``
 We are going to lean heavily on the regular instructions for :doc:`PHP FastCGI <../examples/phpfcgi>`. Just keep in mind that we are using Unix sockets, and not binding the Zend Sever PHP CGI process to a TCP/IP port. Therefore, this is what our configuration for PHP looks like. Also note: this is just the part in regards to plain PHP, most likely you would also want to make sure, no requests will be forwarded to Zend Server for any of your static or cached content!!
 
 .. code-block:: nginx

--- a/source/start/topics/tutorials/commandline.rst
+++ b/source/start/topics/tutorials/commandline.rst
@@ -5,16 +5,16 @@
 CommandLine
 ===========
 
-Starting, Stopping, and Restarting Nginx
+Starting, Stopping, and Restarting NGINX
 ----------------------------------------
-This page shows you how to start Nginx, and once it's running, how to control it so that it will stop or restart.
+This page shows you how to start NGINX, and once it's running, how to control it so that it will stop or restart.
 
 
-Starting Nginx
+Starting NGINX
 ^^^^^^^^^^^^^^
-Nginx is invoked from the command line, usually from ``/usr/bin/nginx``.
+NGINX is invoked from the command line, usually from ``/usr/bin/nginx``.
 
-Basic Example of Starting Nginx
+Basic Example of Starting NGINX
 """""""""""""""""""""""""""""""
 
 .. code-block:: bash
@@ -22,7 +22,7 @@ Basic Example of Starting Nginx
   /usr/bin/nginx
 
 
-Advanced Example of Starting Nginx
+Advanced Example of Starting NGINX
 """"""""""""""""""""""""""""""""""
 
 .. code-block:: bash
@@ -38,10 +38,10 @@ Options
 +-------------------+-----------------------------------------------------------------------------------------------------+
 | ``-v``            | Print version.                                                                                      |
 +-------------------+-----------------------------------------------------------------------------------------------------+
-| ``-V``            | Print nginx version, compiler version and configure parameters.                                     |
+| ``-V``            | Print NGINX version, compiler version and configure parameters.                                     |
 +-------------------+-----------------------------------------------------------------------------------------------------+
 | ``-t``            | Don't run, just test the configuration file.                                                        |
-|                   | Nginx checks configuration for correct syntax and then try to open files referred in configuration. |
+|                   | NGINX checks configuration for correct syntax and then try to open files referred in configuration. |
 +-------------------+-----------------------------------------------------------------------------------------------------+
 | ``-q``            | Suppress non-error messages during configuration testing.                                           |
 +-------------------+-----------------------------------------------------------------------------------------------------+
@@ -49,26 +49,26 @@ Options
 +-------------------+-----------------------------------------------------------------------------------------------------+
 | ``-p prefix``     | Set prefix path (default: ``/usr/local/nginx/``). (version >= 0.7.53)                               |
 +-------------------+-----------------------------------------------------------------------------------------------------+
-| ``-c filename``   | Specify which configuration file Nginx should use instead of the default.                           |
+| ``-c filename``   | Specify which configuration file NGINX should use instead of the default.                           |
 +-------------------+-----------------------------------------------------------------------------------------------------+
 | ``-g directives`` | Set `global <|HttpCoreModule|>`_ directives. (version >= 0.7.4)                                     |
 +-------------------+-----------------------------------------------------------------------------------------------------+
 
-.. note:: Nginx has only a few command-line parameters. Unlike many other software systems, the configuration is done entirely via the configuration file (imagine that).
+.. note:: NGINX has only a few command-line parameters. Unlike many other software systems, the configuration is done entirely via the configuration file (imagine that).
 
 
-Stopping or Restarting Nginx
+Stopping or Restarting NGINX
 ----------------------------
-There are two ways to control Nginx once it's already running.
-The first is to call Nginx again with the ``-s`` command line parameter.
-For example, ``/usr/bin/nginx -s stop`` will stop the Nginx server.
+There are two ways to control NGINX once it's already running.
+The first is to call NGINX again with the ``-s`` command line parameter.
+For example, ``/usr/bin/nginx -s stop`` will stop the NGINX server.
 (other ``-s`` options are given in the previous section)
 
-The second way to control Nginx is to send a signal to the Nginx master process...
-By default nginx writes its master process id to ``/usr/local/nginx/logs/nginx.pid``.
+The second way to control NGINX is to send a signal to the NGINX master process...
+By default NGINX writes its master process id to ``/usr/local/nginx/logs/nginx.pid``.
 You can change this by passing parameter with ``./configure`` at compile-time or by using ``pid`` directive in the configuration file.
 
-Here's how to send the ``QUIT`` (Graceful Shutdown) signal to the Nginx master process:
+Here's how to send the ``QUIT`` (Graceful Shutdown) signal to the NGINX master process:
 
 .. code-block:: bash
 
@@ -110,7 +110,7 @@ However, they support some signals, too:
 
 Loading a New Configuration Using Signals
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Nginx supports a few signals that you can use to control it's operation while it's running.
+NGINX supports a few signals that you can use to control it's operation while it's running.
 
 The most common of these is 15, which just stops the running process:
 
@@ -120,7 +120,7 @@ The most common of these is 15, which just stops the running process:
   root      2213  0.0  0.0   6784  2036 ?        Ss   03:01   0:00 nginx: master process /usr/sbin/nginx -c /etc/nginx/nginx.conf
 
 
-The more interesting option however, is being able to change the nginx configuration on the fly (notice that we test the configuration prior to reloading it):
+The more interesting option however, is being able to change the NGINX configuration on the fly (notice that we test the configuration prior to reloading it):
 
 .. code-block:: bash
 
@@ -130,18 +130,18 @@ The more interesting option however, is being able to change the nginx configura
   root      2213  0.0  0.0   6784  2036 ?        Ss   03:01   0:00 nginx: master process /usr/sbin/nginx -c /etc/nginx/nginx.conf
 
 
-What happens is that when nginx receives the ``HUP`` signal, it tries to parse the configuration file (the specified one, if present, otherwise the default), and if successful, tries to apply a new configuration (i.e. re-open the log files and listen sockets).
-If successful, nginx runs new worker processes and signals graceful shutdown to old workers.
+What happens is that when NGINX receives the ``HUP`` signal, it tries to parse the configuration file (the specified one, if present, otherwise the default), and if successful, tries to apply a new configuration (i.e. re-open the log files and listen sockets).
+If successful, NGINX runs new worker processes and signals graceful shutdown to old workers.
 Notified workers close listen sockets but continue to serve current clients.
 After serving all clients old workers shutdown.
-If nginx couldn't successfully apply the new configuration, it continues to work with an old configuration.
+If NGINX couldn't successfully apply the new configuration, it continues to work with an old configuration.
 
 RequestForReviewCategory -- (Request For Review: Just What Happens With The Worker Processes at a HUP? -Olle)
 
 
 Upgrading To a New Binary On The Fly
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-If you need to replace nginx binary with a new one (when upgrading to a new version or adding/removing server modules), you can do it without any service downtime - no incoming requests will be lost.
+If you need to replace NGINX binary with a new one (when upgrading to a new version or adding/removing server modules), you can do it without any service downtime - no incoming requests will be lost.
 
 First, replace old binary with a new one, then send USR2 signal to the master process. It renames its ``.pid`` file to ``.oldbin`` (e.g. ``/usr/local/nginx/logs/nginx.pid.oldbin``), then executes a new binary, which in turn starts a new master process and the new worker processes:
 
@@ -158,7 +158,7 @@ First, replace old binary with a new one, then send USR2 signal to the master pr
   36267 36264 nobody   0.0  1364 kqread nginx: worker process (nginx)
 
 
-At this point, two instances of nginx are running, handling the incoming requests together.
+At this point, two instances of NGINX are running, handling the incoming requests together.
 To phase the old instance out, you have to send ``WINCH`` signal to the old master process, and its worker processes will start to gracefully shut down:
 
 .. code-block:: bash

--- a/source/start/topics/tutorials/config_pitfalls.rst
+++ b/source/start/topics/tutorials/config_pitfalls.rst
@@ -17,11 +17,11 @@ This Guide Says
 The most frequent issue we see happens when someone attempts to just copy and
 paste a configuration snippet from some other guide. Not all guides out there
 are wrong, but a scary number of them are. Even the Linode library has poor
-quality information that some Nginx community members have futily attempted to
+quality information that some NGINX community members have futily attempted to
 correct.
 
 These docs were created and reviewed by community members that work
-directly with all types of Nginx users. This specific document exists only
+directly with all types of NGINX users. This specific document exists only
 because of the volume of common and recurring issues that community members see.
 
 My Issue Isn't Listed
@@ -177,10 +177,10 @@ BAD:
     }
 
 There are actually three problems here. The first being the if. That's what we
-care about now. Why is this bad? Did you read If is Evil? When nginx receives a
+care about now. Why is this bad? Did you read If is Evil? When NGINX receives a
 request no matter what is the subdomain being requested, be it www.example.com or
 just the plain example.com this if directive is **always** evaluated. Since
-you're requesting nginx to check for the Host header for **every request**.
+you're requesting NGINX to check for the Host header for **every request**.
 It's extremely inefficient. You should avoid it. Instead use two server
 directives like the example below.
 
@@ -198,7 +198,7 @@ GOOD:
     }
 
 Besides making the configuration file easier to read. This approach decreases
-nginx processing requirements. We got rid of the spurious if. We're also using
+NGINX processing requirements. We got rid of the spurious if. We're also using
 $scheme which doesn't hardcodes the URI scheme you're using, be it http or
 https.
 
@@ -206,7 +206,7 @@ Check (If) File Exists
 ----------------------
 
 Using if to ensure a file exists is horrible. It's mean. If you have any recent
-version of Nginx you should look at try_files which just made life much easier.
+version of NGINX you should look at try_files which just made life much easier.
 
 BAD:
 
@@ -275,7 +275,7 @@ well, if you don't care about checking for the existence of directories.
 Passing Uncontrolled Requests to PHP
 ------------------------------------
 
-Many example Nginx configurations for PHP on the web advocate passing every URI
+Many example NGINX configurations for PHP on the web advocate passing every URI
 ending in .php to the PHP interpreter. Note that this presents a serious
 security issue on most PHP setups as it may allow arbitrary code execution by
 third parties.
@@ -303,7 +303,7 @@ Options for avoiding this are:
 
 * Set cgi.fix_pathinfo=0 in php.ini. This causes the PHP interpreter to only
   try the literal path given and to stop processing if the file is not found.
-* Ensure that Nginx only passes specific PHP files for execution:
+* Ensure that NGINX only passes specific PHP files for execution:
 
 .. code-block:: nginx
 
@@ -346,9 +346,9 @@ FastCGI Path in Script Filename
 -------------------------------
 
 So many guides out there like to rely on absolute paths to get to your
-information. This is commonly seen in PHP blocks. When you install Nginx from a
+information. This is commonly seen in PHP blocks. When you install NGINX from a
 repository you'll usually wind up being able to toss "include fastcgi_params;"
-in your config. This is a file located in your Nginx root directory which is
+in your config. This is a file located in your NGINX root directory which is
 usually around /etc/nginx/.
 
 GOOD:
@@ -398,7 +398,7 @@ $request_uri we can effectively avoid doing any capturing or matching at all.
 Rewrite Missing ``http://``
 ---------------------------
 
-Very simply, rewrites are relative unless you tell nginx that they're not.
+Very simply, rewrites are relative unless you tell NGINX that they're not.
 Making a rewrite absolute is simple. Add a scheme.
 
 BAD:
@@ -435,7 +435,7 @@ BAD:
 
 Yucky. In this instance, you pass EVERYTHING to PHP. Why? Apache might do this,
 you don't need to. Let me put it this way... The try_files directive exists for
-an amazing reason. It tries files in a specific order. This means that Nginx can
+an amazing reason. It tries files in a specific order. This means that NGINX can
 first try to server the static content. If it can't, then it moves on. This
 means PHP doesn't get involved at all. MUCH faster. Especially if you're serving
 a 1MB image over PHP a few thousand times versus serving it directly. Let's take
@@ -476,8 +476,8 @@ Also GOOD:
     }
 
 It's easy, right? You see if the requested URI exists and can be served by
-Nginx. If not, is it a directory that can be served. If not, then you pass it to
-your proxy. Only when Nginx can't serve that requested URI directly does your
+NGINX. If not, is it a directory that can be served. If not, then you pass it to
+your proxy. Only when NGINX can't serve that requested URI directly does your
 proxy overhead get involved.
 
 Now.. consider how much of your requests are static content, such as images,
@@ -502,7 +502,7 @@ The fix:
 VirtualBox
 ----------
 
-If this does not work, and you're running nginx on a virtual machine in
+If this does not work, and you're running NGINX on a virtual machine in
 VirtualBox, it may be sendfile() that is causing the trouble. Simply comment out
 the sendfile directive or set it to "off". The directive is most likely found in
 your nginx.conf file.:
@@ -514,7 +514,7 @@ your nginx.conf file.:
 Missing (disappearing) HTTP Headers
 -----------------------------------
 
-If you do not explicitly set `underscores_in_headers on`, nginx will silently
+If you do not explicitly set `underscores_in_headers on`, NGINX will silently
 drop HTTP headers with underscores (which are perfectly valid according to the
 HTTP standard). This is done in order to prevent ambiguities when mapping
 headers to CGI variables as both dashes and underscores are mapped to
@@ -549,7 +549,7 @@ NEVER DO THIS!!! (yes, we have seen this)
 When a request is made for /foo, the request is passed to php because the file
 isn't found. This can appear fine, until a request in made for /etc/passwd.
 Yup, you just gave us a list of all users on that server. In some cases, the
-Nginx server is even set up run workers as root. Yup, we now have your user
+NGINX server is even set up run workers as root. Yup, we now have your user
 list as well as password hashes and how they've been hashed. We now own your
 box.
 
@@ -562,7 +562,7 @@ in either ``/var/www/``, ``/srv``, ``/usr/share/www``.
 Using the Default Document Root
 -------------------------------
 
-Nginx packages that exist in Ubuntu, Debian, or other operating systems, as an
+NGINX packages that exist in Ubuntu, Debian, or other operating systems, as an
 easy-to-install package will often provide a 'default' configuration file as
 an example of configuration methods, and will often include a document root to
 hold a basic HTML file.
@@ -576,7 +576,7 @@ during upgrades.
 You should not use the default document root for any site-critical files. There
 is no expectation that the default document root will be left untouched by the
 system and there is an extremely high possibility that your site-critical data
-may be lost upon updates and upgrades to the nginx packages for your operating
+may be lost upon updates and upgrades to the NGINX packages for your operating
 system.
 
 Using a Hostname to Resolve Addresses
@@ -597,12 +597,12 @@ BAD:
 
 You should never use a hostname in a listen directive. While this may work, it
 will come with a large number of issues. One such issue being that the hostname
-may not resolve at boot time or during a service restart. This can cause Nginx
-to be unable to bind to the desired TCP socket which will prevent Nginx from
+may not resolve at boot time or during a service restart. This can cause NGINX
+to be unable to bind to the desired TCP socket which will prevent NGINX from
 starting at all.
 
 A safer practice is to know the IP address that needs to be bound to and use
-that address instead of the hostname. This prevents Nginx from needing to look
+that address instead of the hostname. This prevents NGINX from needing to look
 up the address and removes dependencies on external and internal resolvers.
 
 This same issue applies to upstream locations. While it may not always be

--- a/source/start/topics/tutorials/debugging.rst
+++ b/source/start/topics/tutorials/debugging.rst
@@ -7,9 +7,9 @@ Debugging
 
 Introduction
 ------------
-Nginx has wide range of debugging features, including detailed debug log. 
+NGINX has wide range of debugging features, including detailed debug log. 
 
-.. note:: Most debugging nits are only activated when nginx compiled with *--with-debug* configure argument.
+.. note:: Most debugging nits are only activated when NGINX compiled with *--with-debug* configure argument.
 
 
 
@@ -17,7 +17,7 @@ Debugging log
 -------------
 See `a debugging log <http://nginx.org/en/docs/debugging_log.html>`_ in documentation for details.
 
-To activate debugging log you have to compile nginx with *--with-debug* configure option and set debug level in `error_log <|HttpCoreModule|#error_log>`_ directive.
+To activate debugging log you have to compile NGINX with *--with-debug* configure option and set debug level in `error_log <|HttpCoreModule|#error_log>`_ directive.
 
 It's possible to debug only connections from specified addresses via `debug_connection <|EventModule|#debug_connection>`_ directive.
 
@@ -27,7 +27,7 @@ It's possible to debug only connections from specified addresses via `debug_conn
 
 Core dump
 ---------
-To obtain core dump you usually have to tune your OS. Though nginx simplifies some typical cases and usually adding
+To obtain core dump you usually have to tune your OS. Though NGINX simplifies some typical cases and usually adding
 
 .. code-block:: nginx
 
@@ -41,7 +41,7 @@ to nginx.conf is enough. Then run gdb to obtain backtrace as usual, e.g.
   gdb /path/to/nginx /path/to/cores/nginx.core
   backtrace full
 
-If your gdb backtrace warns that No symbol table info available. then you will need to recompile Nginx with the appropriate compiler flags for debugging symbols.
+If your gdb backtrace warns that No symbol table info available. then you will need to recompile NGINX with the appropriate compiler flags for debugging symbols.
 
 The exact flags required depend on the compiler used. If you use GCC, the flag ``-g`` enables the inclusion of debugging symbols. 
 Additionally disabling compiler optimization using ``-O0`` will make the debugger output easier to understand.
@@ -55,7 +55,7 @@ Additionally disabling compiler optimization using ``-O0`` will make the debugge
 Socket leaks
 ------------
 Sometimes socket leaks happen. 
-This usually results in ``[alert] 15248#0: open socket #123 left in connection 456`` messages in error log on nginx reload/restart/shutdown. 
+This usually results in ``[alert] 15248#0: open socket #123 left in connection 456`` messages in error log on NGINX reload/restart/shutdown. 
 To debug add 
 
 .. code-block:: bash
@@ -63,7 +63,7 @@ To debug add
   debug_points abort;
 
 to ``nginx.conf`` and configure core dumps (see above). 
-This will result in ``abort()`` call once nginx detects leak and core dump.
+This will result in ``abort()`` call once NGINX detects leak and core dump.
 
 Something like this in gdb should be usefull (assuming 456 is connection number from error message from the process which dumped core):
 
@@ -91,4 +91,4 @@ When asking for help with debugging please provide:
 * ``nginx -V`` output
 * full config
 * debug log
-* backtrace (if nginx exits on signal)
+* backtrace (if NGINX exits on signal)

--- a/source/start/topics/tutorials/gettingstarted.rst
+++ b/source/start/topics/tutorials/gettingstarted.rst
@@ -16,7 +16,7 @@ Requirements
 
 Download
 --------
-Go to the :doc:`install` Page of this wiki to download Nginx.
+Go to the :doc:`install` Page of this wiki to download NGINX.
 Alternatively, here is a link to the `English download page <http://nginx.org/en/download.html>`_ and the original `Russian download page <http://sysoev.ru/nginx/download.html>`_.
 
 
@@ -31,7 +31,7 @@ After extracting the source, run these commands from a terminal:
   make
   sudo make install
 
-By default, Nginx will be installed in ``/usr/local/nginx``. You may change this and other options with the :doc:`installoptions`.
+By default, NGINX will be installed in ``/usr/local/nginx``. You may change this and other options with the :doc:`installoptions`.
 
 
 
@@ -45,15 +45,15 @@ Platform-specific Notes and Builds
       #. :doc:`platformgentoo`
    
 #. `x86/64 build for Solaris <https://www.joyent.com/blog/ok-nginx-is-cool>`_
-#. `Nginx for Windows (32-bit); development, stable, and legacy binaries available <http://kevinworthington.com/nginx-for-windows/>`_
+#. `NGINX for Windows (32-bit); development, stable, and legacy binaries available <http://kevinworthington.com/nginx-for-windows/>`_
 
 ..
    Dead links
-   #. `Nginx building script for Slackware <http://dotimes.com/slackbuilds/nginx/>`_
-   #. `How to Compile nginx on MacOSX <http://nginx.darwinports.com/>`_
+   #. `NGINX building script for Slackware <http://dotimes.com/slackbuilds/nginx/>`_
+   #. `How to Compile NGINX on MacOSX <http://nginx.darwinports.com/>`_
 
 
-Running Nginx
+Running NGINX
 -------------
 Start the server by running ``/usr/local/nginx/sbin/nginx`` as root.
 After editing the configuration file at ``/usr/local/nginx/conf/nginx.conf`` to your liking, you can reload the configuration with:
@@ -73,7 +73,7 @@ For Ubuntu, it is located at ``/var/run/nginx.pid``
 
 .. todo::
    ..
-      * :doc:`modules` for learning more about nginx modules
+      * :doc:`modules` for learning more about NGINX modules
       * :doc:`configuration` for a configuration reference
 
 

--- a/source/start/topics/tutorials/install.rst
+++ b/source/start/topics/tutorials/install.rst
@@ -10,7 +10,7 @@ After Installing
 
 .. todo::
    ..
-      The :doc:`configuration` page will give you some help getting things going after you get Nginx installed and the :doc:`../start/topics/tutorials/config_pitfalls.html` page will help keep you from making mistakes that so many users before you did. 
+      The :doc:`configuration` page will give you some help getting things going after you get NGINX installed and the :doc:`../start/topics/tutorials/config_pitfalls.html` page will help keep you from making mistakes that so many users before you did. 
 
 These two pages give you the chance to learn from others mistakes and hard work.
 
@@ -21,7 +21,7 @@ Binary Releases
 
 Prebuilt Packages for Linux and BSD
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Most Linux distributions and BSD variants have Nginx in the usual package repositories and they can be installed via whatever method is normally used to install software (``apt-get`` on Debian, ``emerge`` on Gentoo, ``ports`` on FreeBSD, etc).
+Most Linux distributions and BSD variants have NGINX in the usual package repositories and they can be installed via whatever method is normally used to install software (``apt-get`` on Debian, ``emerge`` on Gentoo, ``ports`` on FreeBSD, etc).
 
 Be aware that these packages are often somewhat out-of-date.
 If you want the latest features and bugfixes, it's recommended to build from source or use packages directly from nginx.org.
@@ -30,7 +30,7 @@ If you want the latest features and bugfixes, it's recommended to build from sou
 
 Official Red Hat/CentOS packages
 --------------------------------
-To add nginx yum repository, create a file named ``/etc/yum.repos.d/nginx.repo`` and paste one of the configurations below:
+To add NGINX yum repository, create a file named ``/etc/yum.repos.d/nginx.repo`` and paste one of the configurations below:
 
 CentOS::
 
@@ -79,7 +79,7 @@ Ubuntu PPA
 ^^^^^^^^^^
 This PPA is maintained by volunteers and is not distributed by nginx.org.  It has some additional compiled-in modules and may be more fitting for your environment.
 
-You can get the latest stable version of Nginx from the `Nginx PPA <https://launchpad.net/~nginx/+archive/ubuntu/development>`_ on Launchpad:
+You can get the latest stable version of NGINX from the `NGINX PPA <https://launchpad.net/~nginx/+archive/ubuntu/development>`_ on Launchpad:
 You will need to have root privileges to perform the following commands.
 
 For Ubuntu 10.04 and newer:
@@ -110,7 +110,7 @@ For other Debian/Ubuntu based distributions, you can try the lucid variant of th
 
 Official Win32 Binaries
 -----------------------
-As of nginx 0.8.50, nginx is now available as an `official Windows binary <http://nginx.org/en/download.html>`_.
+As of NGINX 0.8.50, NGINX is now available as an `official Windows binary <http://nginx.org/en/download.html>`_.
 
 Installation:
 
@@ -137,7 +137,7 @@ In addition, Kevin Worthington maintains earlier `Windows <http://kevinworthingt
 
 Source Releases
 ---------------
-There are currently two versions of Nginx available: ``stable (1.8.x)``, ``mainline (1.9.x)``.
+There are currently two versions of NGINX available: ``stable (1.8.x)``, ``mainline (1.9.x)``.
 The mainline branch gets new features and bugfixes sooner but might introduce new bugs as well.
 Critical bugfixes are backported to the stable branch.
 
@@ -154,7 +154,7 @@ See the `FAQ <faq.is_it_safe_>`.
 
 Stable
 ^^^^^^
-`nginx 1.8.0 <http://nginx.org/download/nginx-1.8.0.tar.gz>`_<br />
+`NGINX 1.8.0 <http://nginx.org/download/nginx-1.8.0.tar.gz>`_<br />
 21 Apr 2015<br />
 `changelog <http://nginx.org/en/CHANGES-1.8>`_
 </div>
@@ -166,7 +166,7 @@ Stable
 
 Mainline
 ^^^^^^^^
-`nginx 1.9.2 <http://nginx.org/download/nginx-1.9.2.tar.gz>`_<br />
+`NGINX 1.9.2 <http://nginx.org/download/nginx-1.9.2.tar.gz>`_<br />
 16 Jun 2015<br />
 `changelog <http://nginx.org/en/CHANGES>`_
 </div>
@@ -181,7 +181,7 @@ Source code repository is at `hg.nginx.org/nginx <http://hg.nginx.org/nginx>`_.
 Older versions can be found `here <http://nginx.org/en/download.html>`_.
 
 
-Building Nginx From Source
+Building NGINX From Source
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 After extracting the source, run these commands from a terminal:
 
@@ -191,7 +191,7 @@ After extracting the source, run these commands from a terminal:
   make
   sudo make install
 
-By default, Nginx will be installed in ``/usr/local/nginx``. You may change this and other options with the :doc:`installoptions`.
+By default, NGINX will be installed in ``/usr/local/nginx``. You may change this and other options with the :doc:`installoptions`.
 
 You might also want to peruse the :doc:`3rd party modules <../../../modules/index>`, since these must be built at compile-time.
 

--- a/source/start/topics/tutorials/installoptions.rst
+++ b/source/start/topics/tutorials/installoptions.rst
@@ -5,7 +5,7 @@
 Installation and Compile-Time Options
 =====================================
 
-The build is configured using the ``./configure`` command. It defines various aspects of the system, including the methods nginx is allowed to use for connection processing.
+The build is configured using the ``./configure`` command. It defines various aspects of the system, including the methods NGINX is allowed to use for connection processing.
 At the end it creates a Makefile. 
 
 The configure command supports the following parameters:
@@ -15,13 +15,13 @@ Files and Permissions
 **--prefix=*path***
   defines a directory that will keep server files. This same directory will also be used for all relative paths set by configure (except for paths to libraries sources) and in the nginx.conf configuration file. It is set to the ``/usr/local/nginx`` directory by default.
 **--sbin-path=*path***
-  sets the name of an nginx executable file. This name is used only during installation. By default the file is named ``prefix/sbin/nginx``.
+  sets the name of an NGINX executable file. This name is used only during installation. By default the file is named ``prefix/sbin/nginx``.
 **--conf-path=*path***
-  sets the name of an ``nginx.conf`` configuration file. If needs be, nginx can always be started with a different configuration file, by specifying it in the command-line parameter ``-c file``. By default the file is named ``prefix/conf/nginx.conf``.
+  sets the name of an ``nginx.conf`` configuration file. If needs be, NGINX can always be started with a different configuration file, by specifying it in the command-line parameter ``-c file``. By default the file is named ``prefix/conf/nginx.conf``.
 **--pid-path=*path***
   sets the name of an nginx.pid file that will store the process ID of the main process. After installation, the file name can always be changed in the ``nginx.conf`` configuration file using the pid directive. By default the file is named ``prefix/logs/nginx.pid``.
 **--error-log-path=*path***
-  sets the name of the primary error, warnings, and diagnostic file. After installation, the file name can always be changed in the ``nginx.conf`` configuration file using the `error log <|HttpCoreModule|#error_log>`_ directive. By default the file is named ``prefix/logs/error.log``. The special "stderr" value tells nginx to log pre-configuration messages to the standard error.
+  sets the name of the primary error, warnings, and diagnostic file. After installation, the file name can always be changed in the ``nginx.conf`` configuration file using the `error log <|HttpCoreModule|#error_log>`_ directive. By default the file is named ``prefix/logs/error.log``. The special "stderr" value tells NGINX to log pre-configuration messages to the standard error.
 **--http-log-path=*path***
   sets the name of the primary request log file of the HTTP server. After installation, the file name can always be changed in the ``nginx.conf`` configuration file using the `access log <|HttpCoreModule|#access_log>`_ directive. By default the file is named ``prefix/logs/access.log``.
 **--user=*name***
@@ -47,11 +47,11 @@ Optional Modules
 **--with-http_ssl_module**
   enables building a module that adds the HTTPS protocol support to an HTTP server. This module is not built by default. The OpenSSL library is required to build and run this module.
 **--with-pcre=*path***
-  sets the path to the sources of the PCRE library. The library distribution (version 4.4 — 8.21) needs to be downloaded from the PCRE site and extracted. The rest is done by nginx's ``./configure`` and ``make``. The library is required for regular expressions support in the location directive and for the |HttpRewriteModule|. See `notes <installoptions.notes_>`_ below for using system PCRE on FreeBSD systems.
+  sets the path to the sources of the PCRE library. The library distribution (version 4.4 — 8.21) needs to be downloaded from the PCRE site and extracted. The rest is done by NGINX's ``./configure`` and ``make``. The library is required for regular expressions support in the location directive and for the |HttpRewriteModule|. See `notes <installoptions.notes_>`_ below for using system PCRE on FreeBSD systems.
 **--with-pcre-jit**
   builds the PCRE library with "just-in-time compilation" support.
 **--with-zlib=*path***
-  sets the path to the sources of the zlib library. The library distribution (version 1.1.3 — 1.2.5) needs to be downloaded from the zlib site and extracted. The rest is done by nginx's ``./configure`` and ``make``. The library is required for the |HttpGzipModule|.
+  sets the path to the sources of the zlib library. The library distribution (version 1.1.3 — 1.2.5) needs to be downloaded from the zlib site and extracted. The rest is done by NGINX's ``./configure`` and ``make``. The library is required for the |HttpGzipModule|.
 
 Compilation Controls
 ^^^^^^^^^^^^^^^^^^^^

--- a/source/start/topics/tutorials/openbsd.rst
+++ b/source/start/topics/tutorials/openbsd.rst
@@ -2,7 +2,7 @@
 .. meta::
    :description: How to install, build, test, and control NGINX on OpenBSD.
 
-Installing and configuring Nginx / Mongrel on OpenBSD with Rails support
+Installing and configuring NGINX / Mongrel on OpenBSD with Rails support
 ========================================================================
 
 Install the PCRE library
@@ -14,7 +14,7 @@ It is advised you be familiar with installing packages on OpenBSD before proceed
 
     $ sudo pkg_add -v pcre
 
-Download and extract the nginx sources
+Download and extract the NGINX sources
 --------------------------------------
 
 Make sure to appropriately substitute the version numbers below:
@@ -52,12 +52,12 @@ Compile and install
 
     $ make && sudo make install
 
-After nginx has been installed, make sure to edit ``/etc/nginx/nginx.conf`` according to your needs.
+After NGINX has been installed, make sure to edit ``/etc/nginx/nginx.conf`` according to your needs.
 
 Log files
 ---------
 
-By default, nginx saves its logs as ``/var/log/nginx.log`` and ``/var/log/nginx-error.log``. You may wish to configure nginx so that it saves its logs on a per-host basis.
+By default, NGINX saves its logs as ``/var/log/nginx.log`` and ``/var/log/nginx-error.log``. You may wish to configure NGINX so that it saves its logs on a per-host basis.
 
 Initializing Mongrel Cluster from your path/to/app/rails/
 ---------------------------------------------------------
@@ -74,7 +74,7 @@ Initializing Mongrel Cluster from your path/to/app/rails/
          $ sudo mongrel_rails cluster::configure 
          $ sudo mongrel_rails cluster::start
 
-Starting nginx
+Starting NGINX
 --------------
 
 .. code-block:: bash
@@ -88,14 +88,14 @@ Testing, appoint your browser to rails app (localhost, default here)
 
     $ lynx http://localhost
 
-Restarting nginx
+Restarting NGINX
 ----------------
 
 .. code-block:: bash
 
    $ sudo kill -HUP $(head -1 /var/run/nginx.pid)
 
-Shutting down nginx
+Shutting down NGINX
 -------------------
 
 .. code-block:: bash
@@ -105,8 +105,8 @@ Shutting down nginx
 Final notes
 -----------
 
-The initial motivation for this article was a rapid introduction to install and setup nginx on OpenBSD.
-Currently exist a port under ``/usr/ports/www/nginx``. It can be the best way to install and handle new nginx versions on this Operating System.
+The initial motivation for this article was a rapid introduction to install and setup NGINX on OpenBSD.
+Currently exist a port under ``/usr/ports/www/nginx``. It can be the best way to install and handle new NGINX versions on this Operating System.
 
 Whenever it article is nice and functional.
 

--- a/source/start/topics/tutorials/optimizations.rst
+++ b/source/start/topics/tutorials/optimizations.rst
@@ -8,9 +8,9 @@ Optimizations
 Hash Tables
 -----------
 
-To assist with the rapid processing of requests, Nginx uses hash tables.
+To assist with the rapid processing of requests, NGINX uses hash tables.
 
-During startup and with each reconfiguration, Nginx selects the smallest
+During startup and with each reconfiguration, NGINX selects the smallest
 possible size for the hash tables, taking into account the size of
 basket, where keys with the coinciding hashed values fall, would not
 exceed the assigned parameter (hash bucket size).
@@ -28,14 +28,14 @@ the number of turnings to memory. If hash bucket size is equal to the
 size of one line of processor cache, then during the search for key the
 number of turnings to memory in the worst case will be equal to two -
 for the first time for determining the address of basket, and the second
-- with the search for key inside the basket. Accordingly, if Nginx gave
+- with the search for key inside the basket. Accordingly, if NGINX gave
 out communication about the need for increasing hash max size or hash
 bucket size, then it is first necessary to increase the first parameter.
 
 Event Models
 ------------
 
-Nginx supports the following methods of treating the connections, which
+NGINX supports the following methods of treating the connections, which
 can be assigned by the ``use`` directive:
 
 -  **select** - standard method. Compiled by default, if the current
@@ -60,7 +60,7 @@ can be assigned by the ``use`` directive:
    However, starting with Linux 2.6.6-mm2, this parameter is no longer
    available, and for each process there is a separate queue of signals,
    the size of which is assigned by RLIMIT\_SIGPENDING. When the queue
-   becomes overcrowded, nginx discards it and begins processing
+   becomes overcrowded, NGINX discards it and begins processing
    connections using the ``poll`` method until the situation normalizes.
 -  **/dev/poll** - the effective method, used on Solaris 7 11/99+, HP/UX
    11.22+ (eventport), IRIX 6.5.15+ and Tru64 UNIX 5.1A+.

--- a/source/start/topics/tutorials/solaris_10_u5.rst
+++ b/source/start/topics/tutorials/solaris_10_u5.rst
@@ -6,9 +6,9 @@ Installing on Solaris 10u5
 ==========================
 
 Before we can proceed with the installation process, we will install
-some dependencies that will be required by nginx. with my setup, I'll
-compile Nginx with openssl and pcre support, So firstly we will compile
-these prerequisites, after that will continue Nginx compilation process.
+some dependencies that will be required by NGINX. with my setup, I'll
+compile NGINX with openssl and pcre support, So firstly we will compile
+these prerequisites, after that will continue NGINX compilation process.
 
 These prerequisites are:
 
@@ -69,7 +69,7 @@ There you will find some folders, the most important one is
 Building/Installing PCRE
 ------------------------
 
-As previously said, to build Nginx for Solaris, we must first satisfy a
+As previously said, to build NGINX for Solaris, we must first satisfy a
 couple of dependencies, namely PCRE (Perl Regular Expression Library)
 and OpenSSL. (Although OpenSSL is not strictly needed, I like to include
 it for completeness.) All builds will be full 64-bit.
@@ -118,10 +118,10 @@ exit. After that we can proceed and continue our compilation process:
    make
    make install
 
-Building/Installing Nginx
+Building/Installing NGINX
 -------------------------
 
-Our final stage is building and installing nginx from source tar ball,
+Our final stage is building and installing NGINX from source tar ball,
 we will follow the same steps as done above with pcre and openssl:
 
 .. code-block:: bash
@@ -130,7 +130,7 @@ we will follow the same steps as done above with pcre and openssl:
    gtar -zxf nginx-0.7.64.tar.gz
    cd nginx-0.7.64
 
-In order to complete nginx compilation process properly in full 64 bit
+In order to complete NGINX compilation process properly in full 64 bit
 mode, we have to edit src/os/unix/ngx\_sunpro\_amd64.il file firstly as
 follows:
 
@@ -158,10 +158,10 @@ save and exit now complete the process:
    make
    make install
 
-Testing Nginx
+Testing NGINX
 =============
 
-After finishing Nginx's installation process, we can now test that
+After finishing NGINX's installation process, we can now test that
 everything is fine as follows:
 
 .. code-block:: bash
@@ -169,14 +169,14 @@ everything is fine as follows:
    cd /opt/local/nginx/sbin/
    ./nginx
 
-Nginx now should be running on your machine. If you open
+NGINX now should be running on your machine. If you open
 \http://127.0.0.1/ in your browser, you should see a page with “Welcome
 to nginx!”.
 
-Running Nginx as SMF service
+Running NGINX as SMF service
 ============================
 
-In this section we will configure our Nginx Web server to run at Solaris
+In this section we will configure our NGINX Web server to run at Solaris
 10 bootup , and to achieve this we will use Solaris 10 SMF feature, and
 to simplify the process I've created the necessary files for that
 purpose.
@@ -194,14 +194,14 @@ And put the following inside the file:
    NGINX_CONF="/opt/local/nginx/conf/nginx.conf"
    RETVAL=0
    start() {
-      echo "Starting Nginx Web Server: \c"
+      echo "Starting NGINX Web Server: \c"
       $NGINX_CMD -c $NGINX_CONF &
       RETVAL=$?
       [ $RETVAL -eq 0 ] && echo "ok" || echo "failed"
       return $RETVAL
    }
    stop() {
-      echo "Stopping Nginx Web Server: \c"
+      echo "Stopping NGINX Web Server: \c"
       NGINX_PID=`ps -ef |grep $NGINX_CMD |grep -v grep |awk '{print $2}'`
       kill $NGINX_PID
       RETVAL=$?
@@ -264,7 +264,7 @@ Inside the file, put the following:
 
    <common_name>
 
-   <loctext xml:lang='C'> Nginx 0.7.64 </loctext>
+   <loctext xml:lang='C'> NGINX 0.7.64 </loctext>
 
    </common_name> <documentation>
 

--- a/source/start/topics/tutorials/solaris_11.rst
+++ b/source/start/topics/tutorials/solaris_11.rst
@@ -6,7 +6,7 @@ Installing on Solaris 11
 ========================
 
 Please see :doc:`solaris_10_u5` for a detailed
-walkthrough, this is the bare essentials for installing nginx on Solaris
+walkthrough, this is the bare essentials for installing NGINX on Solaris
 11. Solaris 11 has much improved versions of PCRE and OpenSSL so it's
 not required to install them manually.
 
@@ -39,7 +39,7 @@ http://wiki.openindiana.org/oi/Spec+Files+Extra+Repository)
     pkg install developer/library/lint
     pkg install library/pcre
 
-Fetch and compile nginx
+Fetch and compile NGINX
 -----------------------
 
 .. code-block:: bash
@@ -65,14 +65,14 @@ Create the file /lib/svc/method/svc-nginx with the following content:
     NGINX_CONF="/opt/nginx/conf/nginx.conf"
     RETVAL=0
     start() {
-       echo "Starting Nginx Web Server: \c"
+       echo "Starting NGINX Web Server: \c"
        $NGINX_CMD -c $NGINX_CONF &
        RETVAL=$?
        [ $RETVAL -eq 0 ] && echo "ok" || echo "failed"
        return $RETVAL
     }
     stop() {
-       echo "Stopping Nginx Web Server: \c"
+       echo "Stopping NGINX Web Server: \c"
        NGINX_PID=`ps -ef |grep $NGINX_CMD |grep -v grep |awk '{print $2}'`
        kill $NGINX_PID
        RETVAL=$?
@@ -114,7 +114,7 @@ version number.
         <stability value='Stable' /> 
         <template> 
           <common_name>
-            <loctext xml:lang='C'> Nginx 1.4.3 </loctext> 
+            <loctext xml:lang='C'> NGINX 1.4.3 </loctext> 
           </common_name>
           <documentation> 
             <manpage title='nginx' section='8' manpath='/usr/share/man' /> 


### PR DESCRIPTION
Applied NGINX capitalization standards to all wiki pages except the third party module pages.

My apologies for the large PR, but the changes should be easy to review.