### PR TITLE
Make NGINX the test server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-PAPER         =
 BUILDDIR      = build
 
 # User-friendly check for sphinx-build
@@ -13,180 +12,40 @@ $(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx in
 endif
 
 # Internal variables.
-PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 # the i18n builder cannot share the environment and doctrees with the others
-I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+I18NSPHINXOPTS  = $(SPHINXOPTS) source
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
+.PHONY: help clean html dirhtml serve linkcheck gettext
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
-	@echo "  singlehtml to make a single large HTML file"
-	@echo "  pickle     to make pickle files"
-	@echo "  json       to make JSON files"
-	@echo "  htmlhelp   to make HTML files and a HTML help project"
-	@echo "  qthelp     to make HTML files and a qthelp project"
-	@echo "  applehelp  to make an Apple Help Book"
-	@echo "  devhelp    to make HTML files and a Devhelp project"
-	@echo "  epub       to make an epub"
-	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
-	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
-	@echo "  latexpdfja to make LaTeX files and run them through platex/dvipdfmx"
-	@echo "  text       to make text files"
-	@echo "  man        to make manual pages"
-	@echo "  texinfo    to make Texinfo files"
-	@echo "  info       to make Texinfo files and run them through makeinfo"
+	@echo "  serve      to make HTML files and serve with a local NGINX"
 	@echo "  gettext    to make PO message catalogs"
-	@echo "  changes    to make an overview of all changed/added/deprecated items"
-	@echo "  xml        to make Docutils-native XML files"
-	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
 	@echo "  linkcheck  to check all external links for integrity"
-	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
-	@echo "  coverage   to run coverage check of the documentation (if enabled)"
 
 clean:
 	rm -rf $(BUILDDIR)/*
 
-html:
-	$(SPHINXBUILD) -W -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+html: dirhtml
 
 dirhtml:
 	$(SPHINXBUILD) -W -a -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+	@if [ ! -e $(BUILDDIR)/html ]; then cd $(BUILDDIR); ln -s dirhtml html; cd -; fi
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
-singlehtml:
-	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
-	@echo
-	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
-
-pickle:
-	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
-	@echo
-	@echo "Build finished; now you can process the pickle files."
-
-json:
-	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
-	@echo
-	@echo "Build finished; now you can process the JSON files."
-
-htmlhelp:
-	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
-	@echo
-	@echo "Build finished; now you can run HTML Help Workshop with the" \
-	      ".hhp project file in $(BUILDDIR)/htmlhelp."
-
-qthelp:
-	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
-	@echo
-	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
-	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/NginxWiki.qhcp"
-	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/NginxWiki.qhc"
-
-applehelp:
-	$(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp
-	@echo
-	@echo "Build finished. The help book is in $(BUILDDIR)/applehelp."
-	@echo "N.B. You won't be able to view it unless you put it in" \
-	      "~/Library/Documentation/Help or install it in your application" \
-	      "bundle."
-
-devhelp:
-	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
-	@echo
-	@echo "Build finished."
-	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/NginxWiki"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/NginxWiki"
-	@echo "# devhelp"
-
-epub:
-	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
-	@echo
-	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
-
-latex:
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
-	@echo
-	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
-	@echo "Run \`make' in that directory to run these through (pdf)latex" \
-	      "(use \`make latexpdf' here to do that automatically)."
-
-latexpdf:
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
-	@echo "Running LaTeX files through pdflatex..."
-	$(MAKE) -C $(BUILDDIR)/latex all-pdf
-	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
-
-latexpdfja:
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
-	@echo "Running LaTeX files through platex and dvipdfmx..."
-	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
-	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
-
-text:
-	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
-	@echo
-	@echo "Build finished. The text files are in $(BUILDDIR)/text."
-
-man:
-	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
-	@echo
-	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
-
-texinfo:
-	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
-	@echo
-	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
-	@echo "Run \`make' in that directory to run these through makeinfo" \
-	      "(use \`make info' here to do that automatically)."
-
-info:
-	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
-	@echo "Running Texinfo files through makeinfo..."
-	make -C $(BUILDDIR)/texinfo info
-	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
+serve: dirhtml
+	./serve.sh
 
 gettext:
 	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
 	@echo
 	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
 
-changes:
-	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
-	@echo
-	@echo "The overview file is in $(BUILDDIR)/changes."
-
 linkcheck:
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
-
-doctest:
-	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
-	@echo "Testing of doctests in the sources finished, look at the " \
-	      "results in $(BUILDDIR)/doctest/output.txt."
-
-coverage:
-	$(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) $(BUILDDIR)/coverage
-	@echo "Testing of coverage in the sources finished, look at the " \
-	      "results in $(BUILDDIR)/coverage/python.txt."
-
-xml:
-	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
-	@echo
-	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
-
-pseudoxml:
-	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
-	@echo
-	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."

--- a/README.rst
+++ b/README.rst
@@ -37,15 +37,23 @@ You can then build the docs with:
 
 .. code-block:: bash
 
-   $ make html
+   $ make dirhtml
 
-The HTML output is stored in the ``build/html`` directory. You can view this any way you desire, a very easy way to do it is to use PHP's built-in web server:
+The HTML output is stored in the ``build/dirhtml`` directory. You can view this any way you desire, a very easy way to do it is to use NGINX. The build system can execute NGINX using:
 
 .. code-block:: bash
 
-   $ cd build/html
-   $ php -S localhost:8000
+   $ make serve
 
+Or if you have NGINX in a non-standard path (for example ``/opt/nginx/``) you can point to the path of the NGINX binary with:
+
+.. code-block:: bash
+
+   $ NGINX_PATH=/opt/nginx/sbin make serve
+
+NGINX will be started on port 8080 so you can view the wiki by browsing to http://localhost:8080/
+
+When you are done, **CTRL-C** will exit NGINX.
 Contributing
 ------------
 

--- a/serve.sh
+++ b/serve.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+TMPFILE=`mktemp /tmp/nginx.conf.XXXXXX`
+printf "error_log stderr info; pid /dev/null; daemon off; master_process off; events {} http { log_format simple '[\$time_local] \$remote_addr:\$remote_port [\$status]: \$request';access_log /dev/fd/2 simple; server { listen 8080; root .;} types {text.html html;text/css css;}}" >$TMPFILE
+
+if [ -z $NGINX_PATH ]; then
+    nginx -c $TMPFILE -p build/dirhtml
+else
+    $NGINX_PATH/nginx -c $TMPFILE -p build/dirhtml
+fi
+
+rm -f $TMPFILE

--- a/source/contributing/github.rst
+++ b/source/contributing/github.rst
@@ -75,25 +75,26 @@ Once your edits are ready to test, run these commands to check that they build c
 
 .. code-block:: bash
 
-   $ make html
+   $ make dirhtml
    $ make linkcheck
 
-.. note::
+If either command generates an error, your edits probably need fixing. The NGINX developer relations team will be happy to assist you with this.
 
-    The rendered output used by the published wiki is using ``make dirhtml`` which is identical but has a wiki page per directory rather than per html file.
-
-    In addition the full output is rebuilt on every execution of ``make dirhtml`` rather than just the changes with ``make html``.
-
-If either command generates an error, your edits probably need fixing. The NGINX community team will be happy to assist you with this.
-
-One way to preview the output is with PHP's built-in server:
+One way to preview the output is to use NGINX. The build system can alread setup NGINX for you if you have it installed:
 
 .. code-block:: bash
 
-   $ cd build/html/
-   $ php -S localhost:8000
+   $ make serve
 
-You can then use your web browser to go to ``http://localhost:8000/`` and view the result.
+Or if you have NGINX in a non-standard path (for example ``/opt/nginx/``) you can point to the path of the NGINX binary with:
+
+.. code-block:: bash
+
+   $ NGINX_PATH=/opt/nginx/sbin make serve
+
+You can then use your web browser to go to ``http://localhost:8080/`` and view the result.
+
+When you are done, **CTRL-C** will exit NGINX.
 
 Commit and Push
 ---------------


### PR DESCRIPTION
Instead of suggesting PHP's web server, use NGINX itself to test the
wiki. This commit does the following:

* Stip out parts of the make file we don't need
* Turns 'make html' into an alias of 'make dirhtml'
* 'make dirhtml' creates a symlink so that the 'build/html' path still
works
* Added serve.sh which will create a temporary configuration and execute
NGINX
* Added 'make serve' which runs 'make dirhtml' and then 'serve.sh'
* Updated the docs around this

Thanks to Sergey Budnevitch for the idea and basic concept of how to do
this.

Closes #171