### PR TITLE
Update drupal.rst

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -57,7 +57,7 @@ Recipe
 
         location / {
             # try_files $uri @rewrite; # For Drupal <= 6
-            try_files $uri /index.php; # For Drupal >= 7
+            try_files $uri /index.php?$query_string; # For Drupal >= 7
         }
 
         location @rewrite {


### PR DESCRIPTION
This change solves the problem with batch scripts (/batch?op=start&id=x) failing with 403 code (as well as some other operations like flushing all caches via admin menu)