### PR TITLE
lua: we missed the "See Also" section during the original wiki->rst conversion.

### DIFF
--- a/source/modules/lua.rst
+++ b/source/modules/lua.rst
@@ -177,6 +177,11 @@ Copyright and License
 
 See :github:`openresty/lua-nginx-module#copyright-and-license`
 
+See Also
+--------
+
+See :github:`openresty/lua-nginx-module#see-also`
+
 Directives
 ----------
 


### PR DESCRIPTION
now we added it back.