### PR TITLE
Patch 1

### DIFF
--- a/source/start/topics/tutorials/solaris_11.rst
+++ b/source/start/topics/tutorials/solaris_11.rst
@@ -60,41 +60,41 @@ Create the file /lib/svc/method/svc-nginx with the following content:
 
 .. code-block:: bash
 
-   #!/bin/sh
-   unalias stop
-   NGINX_CMD="/opt/nginx/sbin/nginx"
-   NGINX_CONF="/opt/nginx/conf/nginx.conf"
-   RETVAL=0
-   start() {
-      echo "Starting NGINX Web Server: \c"
-      $NGINX_CMD -c $NGINX_CONF &
-      RETVAL=$?
-      [ $RETVAL -eq 0 ] && echo "ok" || echo "failed"
-      return $RETVAL
-   }
-   stop() {
-      echo "Stopping NGINX Web Server: \c"
-      $NGINX_CMD -s quit
-      RETVAL=$?
-      [ $RETVAL -eq 0 ] && echo "ok" || echo "failed"
-      return $RETVAL
-   }
-   case "$1" in
-      start)
-         start
-         ;;
-      stop)
-         stop
-         ;;
-      restart)
-         stop
-         start
-         ;;
-      *)
-         echo "Usage: $0 {start|stop|restart}"
-         exit 1
-   esac
-   exit $RETVAL
+    #!/bin/sh
+    unalias stop
+    NGINX_CMD="/opt/nginx/sbin/nginx"
+    NGINX_CONF="/opt/nginx/conf/nginx.conf"
+    RETVAL=0
+    start() {
+       echo "Starting NGINX Web Server: \c"
+       $NGINX_CMD -c $NGINX_CONF &
+       RETVAL=$?
+       [ $RETVAL -eq 0 ] && echo "ok" || echo "failed"
+       return $RETVAL
+    }
+    stop() {
+       echo "Stopping NGINX Web Server: \c"
+       $NGINX_CMD -s quit
+       RETVAL=$?
+       [ $RETVAL -eq 0 ] && echo "ok" || echo "failed"
+       return $RETVAL
+    }
+    case "$1" in
+       start)
+          start
+          ;;
+       stop)
+          stop
+          ;;
+       restart)
+          stop
+          start
+          ;;
+       *)
+          echo "Usage: $0 {start|stop|restart}"
+          exit 1
+    esac
+    exit $RETVAL
 
 
 Create the manifest: /var/svc/manifest/network/nginx.xml (almost same

--- a/source/start/topics/tutorials/solaris_11.rst
+++ b/source/start/topics/tutorials/solaris_11.rst
@@ -96,7 +96,6 @@ Create the file /lib/svc/method/svc-nginx with the following content:
     esac
     exit $RETVAL
 
-
 Create the manifest: /var/svc/manifest/network/nginx.xml (almost same
 but correct typo in stability to "Stable" with a capital S, and new
 version number.

--- a/source/start/topics/tutorials/solaris_11.rst
+++ b/source/start/topics/tutorials/solaris_11.rst
@@ -60,41 +60,42 @@ Create the file /lib/svc/method/svc-nginx with the following content:
 
 .. code-block:: bash
 
-    #!/bin/sh
-    NGINX_CMD="/opt/nginx/sbin/nginx"
-    NGINX_CONF="/opt/nginx/conf/nginx.conf"
-    RETVAL=0
-    start() {
-       echo "Starting NGINX Web Server: \c"
-       $NGINX_CMD -c $NGINX_CONF &
-       RETVAL=$?
-       [ $RETVAL -eq 0 ] && echo "ok" || echo "failed"
-       return $RETVAL
-    }
-    stop() {
-       echo "Stopping NGINX Web Server: \c"
-       NGINX_PID=`ps -ef |grep $NGINX_CMD |grep -v grep |awk '{print $2}'`
-       kill $NGINX_PID
-       RETVAL=$?
-       [ $RETVAL -eq 0 ] && echo "ok" || echo "failed"
-       return $RETVAL
-    }
-    case "$1" in
-       start)
-          start
-          ;;
-       stop)
-          stop
-          ;;
-       restart)
-          stop
-          start
-          ;;
-       *)
-          echo "Usage: $0 {start|stop|restart}"
-          exit 1
-    esac
-    exit $RETVAL
+   #!/bin/sh
+   unalias stop
+   NGINX_CMD="/opt/nginx/sbin/nginx"
+   NGINX_CONF="/opt/nginx/conf/nginx.conf"
+   RETVAL=0
+   start() {
+      echo "Starting NGINX Web Server: \c"
+      $NGINX_CMD -c $NGINX_CONF &
+      RETVAL=$?
+      [ $RETVAL -eq 0 ] && echo "ok" || echo "failed"
+      return $RETVAL
+   }
+   stop() {
+      echo "Stopping NGINX Web Server: \c"
+      $NGINX_CMD -s quit
+      RETVAL=$?
+      [ $RETVAL -eq 0 ] && echo "ok" || echo "failed"
+      return $RETVAL
+   }
+   case "$1" in
+      start)
+         start
+         ;;
+      stop)
+         stop
+         ;;
+      restart)
+         stop
+         start
+         ;;
+      *)
+         echo "Usage: $0 {start|stop|restart}"
+         exit 1
+   esac
+   exit $RETVAL
+
 
 Create the manifest: /var/svc/manifest/network/nginx.xml (almost same
 but correct typo in stability to "Stable" with a capital S, and new


### PR DESCRIPTION
1. Add "unalias stop". Without this, the script cannot stop or restart the service. For reason, please "man ksh", then search "stop".
2. Replace the stop method to "$NGINX_CMD -s quit".