### PR TITLE
Update Drupal recipe to make it compatible with Drupal 8.

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -21,7 +21,7 @@ Recipe
 
     server {
         server_name example.com;
-        root /var/www/drupal7; ## <-- Your only path reference.
+        root /var/www/drupal8; ## <-- Your only path reference.
 
         location = /favicon.ico {
             log_not_found off;
@@ -64,8 +64,8 @@ Recipe
             rewrite ^/(.*)$ /index.php?q=$1;
         }
 
-        location ~ \.php$ {
-            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        location ~ \.php(/|$) {
+            fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $request_filename;


### PR DESCRIPTION
The changes in this PR are necessary in order for all features of Drupal 8 to work correctly under Nginx. This recipe should still work fine under Drupal 7 with these changes.

Symptoms of not having the right Nginx configuration for Drupal 8:

- Clicking on "Continue" button from update.php gives "Page not found" on update.php/selection page, instead of running updatedb.
- Installing a module from the Admin pages gives an AJAX error instead of installing the module.
- The 'is-active' class is not applied to active elements, so CSS styling is not applied to some active menu items (e.g. when the main navigation menu is moved to a block)

Also changed the docroot to "drupal8", for documentation purposes. :)