### PR TITLE
nginx-faq: fix sed replaces $ twice

### DIFF
--- a/source/community/faq.rst
+++ b/source/community/faq.rst
@@ -59,7 +59,7 @@ How do I generate an .htpasswd file without having Apache tools installed?
 
   .. code-block:: bash
 
-    (PASSWORD="SEcRe7PwD";SALT="$(openssl rand -base64 3)";SHA1=$(printf "$PASSWORD$SALT" | openssl dgst -binary -sha1 | sed 's#$#'"$SALT"'#' | base64);printf "Jim:{SSHA}$SHA1\n" >> .htpasswd) # this example uses SSHA encryption
+    (PASSWORD="SEcRe7PwD";SALT="$(openssl rand -base64 3)";SHA1=$(printf "$PASSWORD$SALT" | openssl dgst -binary -sha1 | xxd -ps | sed 's#$#'"`echo -n $SALT | xxd -ps`"'#' | xxd -r -ps | base64);printf "Jim:{SSHA}$SHA1\n" >> .htpasswd) # this example uses SSHA encryption
 
 * Or, you may use the following `crypt.pl <https://gist.github.com/3349662>`_ Perl script. Simply save it as (for example) ``crypt.pl`` and ``chmod 700 crypt.pl`` in order to be able to execute it.
 


### PR DESCRIPTION
When binary digest contains a character meaning \n, $ is found twice (or
more, in very rare cases) and SALT is added multiple times. This would
result in unusable password hashes.

Signed-off-by: Jens Rehsack <sno@netbsd.org>