### PR TITLE
Fix build dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python: "3.4"
 
 before_install:
-    - pip install Sphinx commonmark recommonmark
+    - pip install Sphinx commonmark==0.5.5 recommonmark
 
 script:
     - ".ci/${CI_TARGET}.sh"


### PR DESCRIPTION
Commonmark 0.6.0 has been released which breaks recommonmark. Pinning to
0.5.5 (last known-good version)