### PR TITLE
Pin commonmark to 0.5.5 in the docs too

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ There are a couple of extra dependencies you will also need to build the Markdow
 
 .. code-block:: bash
 
-   $ sudo pip install recommonmark commonmark
+   $ sudo pip install recommonmark commonmark==0.5.5
 
 You can then build the docs with:
 

--- a/source/contributing/github.rst
+++ b/source/contributing/github.rst
@@ -21,7 +21,7 @@ You also need *python-sphinx* installed; some Linux distributions have this in t
 
 .. code-block:: bash
 
-   $ pip install -U Sphinx recommonmark commonmark
+   $ pip install -U Sphinx recommonmark commonmark==0.5.5
 
 GitHub's Two-Factor Authentication
 ----------------------------------


### PR DESCRIPTION
0.6 changes API and breaks things so make sure users are installing
the right version.