### PR TITLE
Removed Let's Encrypt reference

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -48,7 +48,7 @@ Recipe
             return 403;
         }
         
-        # Allow Let's Encrypt RFC 5785 ACME protocol
+        # Allow "Well-Known URIs" as per RFC 5785
         location ~* ^/.well-known/ {
             allow all;
         }        


### PR DESCRIPTION
[RFC 5785](https://tools.ietf.org/html/rfc5785) is used by a number of services, not just Let's Encrypt so broadened out the comment.