### PR TITLE
Update the redis.rst

### DIFF
--- a/source/modules/redis.rst
+++ b/source/modules/redis.rst
@@ -9,8 +9,12 @@ Description
 -----------
 
 You can use this module to perform simple caching.  There are plans to extend this module in the near future.
+Latest version available at http://people.FreeBSD.org/~osa/ngx_http_redis-0.3.8.tar.gz.
 
-Latest version available at http://people.FreeBSD.org/~osa/ngx_http_redis-0.3.7.tar.gz.
+Starting from nginx 1.9.11, it's possible to compile this module as a dynamic module, by using the ``--add-dynamic-module=PATH`` option instead of ``--add-module=PATH`` on the ``./configure`` command line.  Then it's possible to explicitly load the module in a ``nginx.conf`` via the ``load_module`` (http://nginx.org/en/docs/ngx_core_module.html#load_module)
+directive:
+
+``load_module /path/to/modules/ngx_http_redis_module.so;``
 
 Example configuration
 


### PR DESCRIPTION
New version of http_redis 0.3.8 has been released, it's possible to build http_redis module as a dynamic module.