### PR TITLE
Clarify nginScript workaround

### DIFF
--- a/source/nginScript.rst
+++ b/source/nginScript.rst
@@ -185,6 +185,7 @@ The following example illustrates how to obtain a parameter from the query strin
       }";
   }
 
+.. note:: If more than one JavaScript functions are defined, the nginScript environment will pass the request and response objects to the function that was defined last.
 
 Section 4: Documentation
 ------------------------


### PR DESCRIPTION
Added a note that explains how the nginScript environment chooses which function to pass the request and response objects to if a ``js_*`` directive has multiple top-level functions.