### PR TITLE
Added documentation link for running Nginx as reverse proxy for Minio Object Storage.

### DIFF
--- a/source/start/index.rst
+++ b/source/start/index.rst
@@ -139,6 +139,7 @@ to work.
 * `Joomla <https://docs.joomla.org/Nginx>`_
 * :doc:`topics/recipes/mailman`
 * :doc:`topics/recipes/mediawiki`
+* `Minio Object Storage <https://docs.minio.io/docs/setup-nginx-proxy-with-minio-server>`_
 * :doc:`topics/recipes/moinmoin`
 * :doc:`topics/recipes/mybb`
 * :doc:`topics/recipes/omeka`


### PR DESCRIPTION
Added documentation link for running Nginx as reverse proxy for Minio Object Storage.