### PR TITLE
Handle private files

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -98,6 +98,11 @@ Recipe
         location ~ ^/sites/.*/files/styles/ { # For Drupal >= 7
             try_files $uri @rewrite;
         }
+       
+        # Handle private files through Drupal.
+        location ~ ^/system/files/ { # For Drupal >= 7
+            try_files $uri /index.php?$query_string;
+        }
 
         location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
             expires max;


### PR DESCRIPTION
Proposed config file was returning 404 for private files (ex. /system/files/foo.jpg) that are handled through Drupal. This snippet fixed it.