### PR TITLE
Update cgi.fix_pathinfo note for Drupal

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -47,12 +47,12 @@ Recipe
         location ~ ^/sites/.*/private/ {
             return 403;
         }
-        
+
         # Allow "Well-Known URIs" as per RFC 5785
         location ~* ^/.well-known/ {
             allow all;
-        }        
-        
+        }
+
         # Block access to "hidden" files and directories whose names begin with a
         # period. This includes directories used by version control systems such
         # as Subversion or Git to store control files.
@@ -75,14 +75,17 @@ Recipe
             return 404;
         }
 
-        # In Drupal 8, we must also match new paths where the '.php' appears in the middle,
-        # such as update.php/selection. The rule we use is strict, and only allows this pattern
-        # with the update.php front controller.  This allows legacy path aliases in the form of
-        # blog/index.php/legacy-path to continue to route to Drupal nodes. If you do not have 
-        # any paths like that, then you might prefer to use a laxer rule, such as: 
+        # In Drupal 8, we must also match new paths where the '.php' appears in
+        # the middle, such as update.php/selection. The rule we use is strict,
+        # and only allows this pattern with the update.php front controller.
+        # This allows legacy path aliases in the form of
+        # blog/index.php/legacy-path to continue to route to Drupal nodes. If
+        # you do not have any paths like that, then you might prefer to use a
+        # laxer rule, such as:
         #   location ~ \.php(/|$) {
-        # The laxer rule will continue to work if Drupal uses this new URL pattern with front
-        # controllers other than update.php in a future release.
+        # The laxer rule will continue to work if Drupal uses this new URL
+        # pattern with front controllers other than update.php in a future
+        # release.
         location ~ '\.php$|^/update.php' {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
             #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
@@ -98,7 +101,7 @@ Recipe
         location ~ ^/sites/.*/files/styles/ { # For Drupal >= 7
             try_files $uri @rewrite;
         }
-       
+
         # Handle private files through Drupal.
         location ~ ^/system/files/ { # For Drupal >= 7
             try_files $uri /index.php?$query_string;

--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -88,7 +88,9 @@ Recipe
         # release.
         location ~ '\.php$|^/update.php' {
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
-            #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+            # Security note: If you're running a version of PHP older than the
+            # latest 5.3, you should have "cgi.fix_pathinfo = 0;" in php.ini.
+            # See http://serverfault.com/q/627903/94922 for details.
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param PATH_INFO $fastcgi_path_info;


### PR DESCRIPTION
The documentation here states that the following must be in php.ini:

`cgi.fix_pathinfo = 0`

That's no longer the case with newer PHP.  Here's some background with more information:

* [Is the PHP option 'cgi.fix_pathinfo' really dangerous with Nginx + PHP-FPM?](https://serverfault.com/questions/627903/is-the-php-option-cgi-fix-pathinfo-really-dangerous-with-nginx-php-fpm)
* [Setting up PHP-FastCGI and nginx? Don’t trust the tutorials: check your configuration!](https://nealpoole.com/blog/2011/04/setting-up-php-fastcgi-and-nginx-dont-trust-the-tutorials-check-your-configuration/) (notably the hidden comments at the end)

I updated the documentation to state that it's only required for old versions of PHP which don't have the following as default (somewhere like _/etc/php5/fpm/pool.d/www.conf_):

`security.limit_extensions = .php`

While I was in there, I also removed some extra whitespace and trimmed some lines down below 80 characters.