### PR TITLE
Fixed typo that silently fails the Upstart job

### DIFF
--- a/source/start/topics/examples/ubuntuupstart.rst
+++ b/source/start/topics/examples/ubuntuupstart.rst
@@ -14,7 +14,7 @@ Save this file as ``/etc/init/nginx.conf``
    description "nginx http daemon"
    author "George Shammas <georgyo@gmail.com>"
 
-   start on (filesystem and net-device-up IFACE=!lo)
+   start on (filesystem and net-device-up IFACE!=lo)
    stop on runlevel [!2345]
 
    env DAEMON=/usr/sbin/nginx


### PR DESCRIPTION
This upstart script was the only startup script I had on my system (no `/etc/init.d`, no configuration warnings) but nginx would always be stopped after startup. Manual start commands yielded no errors. This fixes the issue.