### PR TITLE
Removed leading semicolon from sample code

### DIFF
--- a/source/modules/java_handler.rst
+++ b/source/modules/java_handler.rst
@@ -35,7 +35,7 @@ In Hello.java
                         NGX_HTTP_OK, //http status 200
                         ArrayMap.create(CONTENT_TYPE, "text/plain"), //headers map
                         "Hello, Java & NGINX!"  //response body can be string, File or Array/Collection of them
-                    };
+                    }
      }
   }
 


### PR DESCRIPTION
I just noticed the java formatter on your blog has error validation built-in and shows a red square around the last semicolon in the sample code.  Hence this PR, I just removed it  ;-)