### PR TITLE
Prevent httpoxy attacks in the Drupal recipe

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -92,6 +92,8 @@ Recipe
             # latest 5.3, you should have "cgi.fix_pathinfo = 0;" in php.ini.
             # See http://serverfault.com/q/627903/94922 for details.
             include fastcgi_params;
+            # Block httpoxy attacks. See https://httpoxy.org/.
+            fastcgi_param HTTP_PROXY "";
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param PATH_INFO $fastcgi_path_info;
             fastcgi_intercept_errors on;


### PR DESCRIPTION
Adds httpoxy protection to the Drupal recipe at https://www.nginx.com/resources/wiki/start/topics/recipes/drupal/.

Closes the vulnerability identified at https://httpoxy.org/.  See also https://www.digitalocean.com/community/tutorials/how-to-protect-your-server-against-the-httpoxy-vulnerability for more detailed fixes.