### PR TITLE
Compiling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,12 +27,6 @@ Alternatively it can be installed with Python's pip package manager:
 
    $ sudo pip install -r requirements.txt
 
-There are a couple of extra dependencies you will also need to build the Markdown parts of the documentation, these are automatically installed with the pip command above:
-
-.. code-block:: bash
-
-   $ sudo pip install recommonmark commonmark==0.5.5
-
 You can then build the docs with:
 
 .. code-block:: bash

--- a/README.rst
+++ b/README.rst
@@ -9,19 +9,7 @@ This is the source repository for the new NGINX wiki. It is written in reStructu
 Compiling
 ---------
 
-To compile a local copy of the documentation you will need Sphinx installed. Most Linux distributions have this in their repositories and can be installed with commands such as:
-
-.. code-block:: bash
-
-   $ sudo apt-get install python-sphinx
-
-or
-
-.. code-block:: bash
-
-   $ sudo yum install python-sphinx
-
-Alternatively it can be installed with Python's pip package manager:
+To compile a local copy of the documentation you will need Sphinx installed. It can be installed with Python's pip package manager:
 
 .. code-block:: bash
 

--- a/source/contributing/github.rst
+++ b/source/contributing/github.rst
@@ -23,12 +23,6 @@ You also need *python-sphinx* installed; some Linux distributions have this in t
 
    $ sudo pip install -r requirements.txt
 
-There are a couple of extra dependencies you will also need to build the Markdown parts of the documentation, these are automatically installed with the pip command above:
-
-.. code-block:: bash
-
-   $ pip install -U Sphinx recommonmark commonmark==0.5.5
-
 GitHub's Two-Factor Authentication
 ----------------------------------
 

--- a/source/contributing/github.rst
+++ b/source/contributing/github.rst
@@ -21,6 +21,12 @@ You also need *python-sphinx* installed; some Linux distributions have this in t
 
 .. code-block:: bash
 
+   $ sudo pip install -r requirements.txt
+
+There are a couple of extra dependencies you will also need to build the Markdown parts of the documentation, these are automatically installed with the pip command above:
+
+.. code-block:: bash
+
    $ pip install -U Sphinx recommonmark commonmark==0.5.5
 
 GitHub's Two-Factor Authentication


### PR DESCRIPTION
After some testing, I have found that that command "sudo pip install -r requirements.txt" is all you need to compile a local copy of the documentation. "pip install recommonmark commonmark==0.5.5" is an unnecessary command because it doesn't install enough dependencies to work on its own, but also doesn't install anything extra when paired with "pip install -r requirements.txt". Therefore I have taken out this command from both the wiki and README.rst. Please let me know if I am incorrect in my tests.