### PR TITLE
Add QUERY_STRING fastcgi parameter to fix modal dialog problem in Drupal 8

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -96,6 +96,7 @@ Recipe
             fastcgi_param HTTP_PROXY "";
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param PATH_INFO $fastcgi_path_info;
+            fastcgi_param QUERY_STRING $query_string;
             fastcgi_intercept_errors on;
             # PHP 5 socket location.
             #fastcgi_pass unix:/var/run/php5-fpm.sock;


### PR DESCRIPTION
Without the fastcgi_param QUERY_STRING the "Place block" modal dialog in Drupal 8 was throwing an ajax error.
