### PR TITLE
Removing index.php from url

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -22,6 +22,14 @@ Recipe
     server {
         server_name example.com;
         root /var/www/drupal8; ## <-- Your only path reference.
+        
+        if ($request_uri ~* "^(.*/)index\.php$") {
+            return 301 $1;
+        }
+        
+        location ~ '^/index\.php/(.*)$' {
+            return 301  $scheme://$server_name/$1;
+        }
 
         location = /favicon.ico {
             log_not_found off;


### PR DESCRIPTION
Going to /index.php should redirect to / for SEO purposes.
Also, having /index.php/myurl should redirect to /myurl. For example. going to https://drupal.com/index.php/case-study/colorado-general-assembly should go to https://drupal.com/case-study/colorado-general-assembly

Index redirect taken from http://stackoverflow.com/questions/21687288/nginx-redirect-loop-remove-index-php-from-url