### PR TITLE
It is normal to have a URI ending in ‘.jpg’ handled by drupal

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -117,6 +117,7 @@ Recipe
         }
 
         location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+            try_files $uri @rewrite;
             expires max;
             log_not_found off;
         }


### PR DESCRIPTION
It is normal to have a URI ending in ‘.jpg’ etc, which is not an actual .jpg file and should be handled by drupal, when using e.g. pathauto, token, or a friendly URL alias (instead of the default /file/# URI) on an object in the media library, so instead of serving the 404 from nginx, let drupal serve the 404 if necessary