### PR TITLE
 Fix issue #235 MediaWiki Recipe: Does Not Work - Blank White Page

### DIFF
--- a/source/start/index.rst
+++ b/source/start/index.rst
@@ -122,6 +122,11 @@ address these quirks and then share the resulting configurations. This has
 resulted in many "copy and paste" configurations that are almost guaranteed
 to work.
 
+If the web applications with the configuration don't work, please check
+whether the simplest web application works. For example, if PHP based web
+applications such as mediawiki don't work, please check if PHP FastCGI 
+(refer to :doc:`topics/examples/phpfcgi`) works.
+
 * `ActiveColab <https://www.howtoforge.com/running-activecollab-3-on-nginx-lemp-on-debian-wheezy-ubuntu-12.10>`_
 * `Chive <https://github.com/perusio/chive-nginx>`_
 * :doc:`topics/recipes/cms_made_simple`

--- a/source/start/topics/recipes/mediawiki.rst
+++ b/source/start/topics/recipes/mediawiki.rst
@@ -10,6 +10,8 @@ Requirements
 
 * `php-fpm <https://php-fpm.org/>`__
 
+* The ``SCRIPT_FILENAME`` parameter is defined in ``fastcgi_params file`` or in parent contexts, for more details, please refer to :doc:`../examples/phpfcgi`
+
 Recipe
 ------
 


### PR DESCRIPTION
1.  Fix issue #235 MediaWiki Recipe: Does Not Work - Blank White Page
Update some PHP examples with the description about fastcgi parameter SCRIPT_FILENAME.
Also update the index page to include the trouble shooting tips.

Before this commit, The PHP FastCGI example and Mediawiki Recipe example won't work on some
Linux distributions as SCRIPT_FILENAME is not set in the build of Nginx.

2. tiny refinement to the PHP FastCGI example.