### PR TITLE
Cache SVG files

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -116,7 +116,7 @@ Recipe
             try_files $uri /index.php?$query_string;
         }
 
-        location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
             try_files $uri @rewrite;
             expires max;
             log_not_found off;


### PR DESCRIPTION
Cache SVG files to improve PageSpeed score on https://developers.google.com/speed/pagespeed/insights