### PR TITLE
Drupal: Block access to php scripts in /sites/*/files/*

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -48,6 +48,11 @@ Recipe
             return 403;
         }
 
+        # Block access to scripts in site files directory
+        location ~ ^/sites/[^/]+/files/.*\.php$ {
+            deny all;
+        }
+
         # Allow "Well-Known URIs" as per RFC 5785
         location ~* ^/.well-known/ {
             allow all;


### PR DESCRIPTION
The default install of drupal includes .htaccess files that block execution of scripts inside the /sites/*/files/ directory. Scripts should be blocked here because this folder is writeable by the server and users