### PR TITLE
Systemd: Check configuration on reload

### DIFF
--- a/source/start/topics/examples/systemd.rst
+++ b/source/start/topics/examples/systemd.rst
@@ -22,7 +22,7 @@ Save this file as ``/lib/systemd/system/nginx.service``
     PIDFile=/run/nginx.pid
     ExecStartPre=/usr/sbin/nginx -t
     ExecStart=/usr/sbin/nginx
-    ExecReload=/bin/kill -s HUP $MAINPID
+    ExecReload=/usr/sbin/nginx -s reload
     ExecStop=/bin/kill -s QUIT $MAINPID
     PrivateTmp=true
 


### PR DESCRIPTION
Sending SIGHUP to the NGINX master process is not exactly equivalent to
using `nginx -s reload`. The latter will go through a part of NGINX
initialization procedure and validate the configuration file.

Thus, if an invalid configuration file is provided and NGINX is reloaded
by sending a signal to the master process, systemd is not able to know
that the reload failed (the signal was sent successfully). On the other
hand, using the NGINX CLI option to reload will validate the
configuration file and report the failure before even sending the signal
to the running NGINX process.