### PR TITLE
examples: Fix reverse proxy caching example

### DIFF
--- a/source/start/topics/examples/reverseproxycachingexample.rst
+++ b/source/start/topics/examples/reverseproxycachingexample.rst
@@ -17,6 +17,7 @@ nginx.conf
           location / {
               proxy_pass             http://1.2.3.4;
               proxy_set_header       Host $host;
+              proxy_buffering        on;
               proxy_cache            STATIC;
               proxy_cache_valid      200  1d;
               proxy_cache_use_stale  error timeout invalid_header updating


### PR DESCRIPTION
NGINX **needs** `proxy_buffering on;` or the caching machinery is silently disabled. Users of NGINX that do not do this will wake up one morning to a very large S3 bill.