### PR TITLE
Update upload_progress title level

### DIFF
--- a/source/modules/upload_progress.rst
+++ b/source/modules/upload_progress.rst
@@ -24,7 +24,7 @@ mod_uploadprogress <http://blog.lighttpd.net/articles/2006/08/01/mod_uploadprogr
 
 
 Downloads
-=========
+^^^^^^^^^
 
 | **Download version**:
 
@@ -52,7 +52,7 @@ Downloads
 
 
 Installation
-============
+^^^^^^^^^^^^
 
 After extracting, add the following option to your NGINX ``./configure``
 command:
@@ -68,7 +68,7 @@ command:
 
 
 Directives
-==========
+^^^^^^^^^^
 
 -  `upload\_progress <#upload_progress>`__
 -  `track\_uploads <#track_uploads>`__
@@ -249,7 +249,7 @@ Example of jsonp response:
 
 
 Configuration Example
-=====================
+^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: nginx
 
@@ -282,7 +282,7 @@ Configuration Example
 
 
 Usage on pure JavaScript
-========================
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 (based on Lighttd mod\_uploadprogress module example):
 
@@ -363,7 +363,7 @@ submit action. This also will start the ajax progress report mechanism.
 
 
 Usage with jQuery Upload Progress
-=================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can use jQuery plugin to work with NGINX upload-progress-module -
 https://github.com/drogus/jquery-upload-progress (based on it's
@@ -474,7 +474,7 @@ Defaults:
 
 
 Companion Software
-==================
+^^^^^^^^^^^^^^^^^^
 
 This software can also work with Valery Kholodkov' NGINX Upload Module:
 http://www.grid.net.ru/nginx/upload.en.html


### PR DESCRIPTION
use 'top' level header cause there are some titles at the end "NGINX 3rd Party Modules" part of right sidebar
https://www.nginx.com/resources/wiki/modules/index.html
