### PR TITLE
Update "location" to avoid 404 page.

### DIFF
--- a/source/start/topics/recipes/symfony.rst
+++ b/source/start/topics/recipes/symfony.rst
@@ -44,7 +44,7 @@ Secure Symfony 4.x
             fastcgi_param DOCUMENT_ROOT $realpath_root;
         }
         # PROD
-        location ~ ^public/index\.php(/|$) {
+        location ~ ^/index\.php(/|$) {
             fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
             fastcgi_split_path_info ^(.+\.php)(/.*)$;
             include fastcgi_params;


### PR DESCRIPTION
"/public" already configured in "root" instruction. It result as a 404 page if "/public" is not removed from the "location" instruction.