### PR TITLE
Fix configuration table column widths

### DIFF
--- a/source/extending/api/configuration.rst
+++ b/source/extending/api/configuration.rst
@@ -52,38 +52,38 @@ ngx_command_t
 
    .. c:member:: ngx_uint_t type
 
-      ================== =========================================================================
-      Type               Description
-      ================== =========================================================================
-      NGX_CONF_NOARGS    Directive has no arguments
-      NGX_CONF_TAKE1     Directive has one argument
-      NGX_CONF_TAKE2     Directive has two arguments
-      NGX_CONF_TAKE3     Directive has three arguments
-      NGX_CONF_TAKE4     Directive has four arguments
-      NGX_CONF_TAKE5     Directive has five arguments
-      NGX_CONF_TAKE6     Directive has six arguments
-      NGX_CONF_TAKE7     Directive has seven arguments
-      NGX_CONF_TAKE12    Directive has one or two arguments (alias for ``NGX_CONF_TAKE1 | NGX_CONF_TAKE2``)
-      NGX_CONF_TAKE13    Directive has one or three arguments (alias for ``NGX_CONF_TAKE1 | NGX_CONF_TAKE3``)
-      NGX_CONF_TAKE23    Directive has two or three arguments (alias for ``NGX_CONF_TAKE2 | NGX_CONF_TAKE3``)
-      NGX_CONF_TAKE123   Directive has one to three arguments (alias for ``NGX_CONF_TAKE1 | NGX_CONF_TAKE2 | NGX_CONF_TAKE3``)
-      NGX_CONF_TAKE1234  Directive has one to four arguments (alias for ``NGX_CONF_TAKE1 | NGX_CONF_TAKE2 | NGX_CONF_TAKE3 | NGX_CONF_TAKE4``)
-      NGX_CONF_BLOCK     Argument is a configuration block
-      NGX_CONF_FLAG      Directive is a flag with values *on* and *off*
-      NGX_CONF_ANY       Directive has zero or more arguments
-      NGX_CONF_1MORE     Directive has one or more arguments
-      NGX_CONF_2MORE     Directive has two or more arguments
-      NGX_DIRECT_CONF    Directive only in the main configuration file
-      NGX_MAIN_CONF      Directive only in the main configuration level
-      NGX_ANY_CONF       Directive can be used in at any level / directive
-      NGX_HTTP_MAIN_CONF Directive for the http directive
-      NGX_HTTP_SRV_CONF  Directive for the server directive inside the http directive
-      NGX_HTTP_LOC_CONF  Directive for the location directive inside the http directive
-      NGX_HTTP_UPS_CONF  Directive for the upstream directive inside the http directive
-      NGX_HTTP_SIF_CONF  Directive for server block if statements
-      NGX_HTTP_LIF_CONF  Directive for location block if statements
-      NGX_HTTP_LMT_CONF  Directive for the *limit_except* block
-      ================== =========================================================================
+      ============================================ ===============================================
+      Type                                         Description
+      ============================================ ===============================================
+      NGX_CONF_NOARGS                              Directive has no arguments
+      NGX_CONF_TAKE1                               Directive has one argument
+      NGX_CONF_TAKE2                               Directive has two arguments
+      NGX_CONF_TAKE3                               Directive has three arguments
+      NGX_CONF_TAKE4                               Directive has four arguments
+      NGX_CONF_TAKE5                               Directive has five arguments
+      NGX_CONF_TAKE6                               Directive has six arguments
+      NGX_CONF_TAKE7                               Directive has seven arguments
+      NGX_CONF_TAKE12                              Directive has one or two arguments (alias for ``NGX_CONF_TAKE1 | NGX_CONF_TAKE2``)
+      NGX_CONF_TAKE13                              Directive has one or three arguments (alias for ``NGX_CONF_TAKE1 | NGX_CONF_TAKE3``)
+      NGX_CONF_TAKE23                              Directive has two or three arguments (alias for ``NGX_CONF_TAKE2 | NGX_CONF_TAKE3``)
+      NGX_CONF_TAKE123                             Directive has one to three arguments (alias for ``NGX_CONF_TAKE1 | NGX_CONF_TAKE2 | NGX_CONF_TAKE3``)
+      NGX_CONF_TAKE1234                            Directive has one to four arguments (alias for ``NGX_CONF_TAKE1 | NGX_CONF_TAKE2 | NGX_CONF_TAKE3 | NGX_CONF_TAKE4``)
+      NGX_CONF_BLOCK                               Argument is a configuration block
+      NGX_CONF_FLAG                                Directive is a flag with values *on* and *off*
+      NGX_CONF_ANY                                 Directive has zero or more arguments
+      NGX_CONF_1MORE                               Directive has one or more arguments
+      NGX_CONF_2MORE                               Directive has two or more arguments
+      NGX_DIRECT_CONF                              Directive only in the main configuration file
+      NGX_MAIN_CONF                                Directive only in the main configuration level
+      NGX_ANY_CONF                                 Directive can be used in at any level / directive
+      NGX_HTTP_MAIN_CONF                           Directive for the http directive
+      NGX_HTTP_SRV_CONF                            Directive for the server directive inside the http directive
+      NGX_HTTP_LOC_CONF                            Directive for the location directive inside the http directive
+      NGX_HTTP_UPS_CONF                            Directive for the upstream directive inside the http directive
+      NGX_HTTP_SIF_CONF                            Directive for server block if statements
+      NGX_HTTP_LIF_CONF                            Directive for location block if statements
+      NGX_HTTP_LMT_CONF                            Directive for the *limit_except* block
+      ============================================ ===============================================
 
    .. c:member:: char *(set)(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
@@ -91,21 +91,21 @@ ngx_command_t
 
       There are several callback handlers already supplied with NGINX which you can use:
 
-      ========================= ======================= ========================================================
-      Callback name             Data type               Description
-      ========================= ======================= ========================================================
-      ngx_conf_set_flag_slot    :c:type:`ngx_flag_t`    Allows ``on`` and ``off`` as values for a boolean
-      ngx_conf_set_str_slot     :c:type:`ngx_str_t`
-      ngx_conf_set_str_array    :c:type:`ngx_array_t` * Returns a pointer to an array of :c:type:`ngx_str_t`
-      ngx_conf_set_keyval_slot  :c:type:`ngx_array_t` * Returns a pointer to an array of :c:type:`ngx_keyval_t`
-      ngx_conf_set_num_slot     :c:type:`ngx_int_t`
-      ngx_conf_set_size_slot    ``size_t``
-      ngx_conf_set_off_slot     ``off_t``
-      ngx_conf_set_msec_slot    :c:type:`ngx_msec_t`
-      ngx_conf_set_sec_slot     ``time_t``
-      ngx_conf_set_bufs_slot    :c:type:`ngx_bufs_t`
-      ngx_conf_set_bitmask_slot :c:type:`ngx_uint_t`
-      ========================= ======================= ========================================================
+      ================================= ======================= ================================================
+      Callback name                     Data type               Description
+      ================================= ======================= ================================================
+      ngx_conf_set_flag_slot            :c:type:`ngx_flag_t`    Allows ``on`` and ``off`` as values for a boolean
+      ngx_conf_set_str_slot             :c:type:`ngx_str_t`
+      ngx_conf_set_str_array            :c:type:`ngx_array_t` * Returns a pointer to an array of :c:type:`ngx_str_t`
+      ngx_conf_set_keyval_slot          :c:type:`ngx_array_t` * Returns a pointer to an array of :c:type:`ngx_keyval_t`
+      ngx_conf_set_num_slot             :c:type:`ngx_int_t`
+      ngx_conf_set_size_slot            ``size_t``
+      ngx_conf_set_off_slot             ``off_t``
+      ngx_conf_set_msec_slot            :c:type:`ngx_msec_t`
+      ngx_conf_set_sec_slot             ``time_t``
+      ngx_conf_set_bufs_slot            :c:type:`ngx_bufs_t`
+      ngx_conf_set_bitmask_slot         :c:type:`ngx_uint_t`
+      ================================= ======================= ================================================
 
       :param cf: The configuration object
       :param cmd: A pointer to this struct


### PR DESCRIPTION
Fixes: https://github.com/nginxinc/nginx-wiki/issues/370

Fixed column widths of configuration table

Example:
Before:
<img width="397" alt="before" src="https://user-images.githubusercontent.com/15719653/44710983-43494080-aaa5-11e8-953a-a5c73d3d5d41.png">

After:
<img width="483" alt="after" src="https://user-images.githubusercontent.com/15719653/44710989-480df480-aaa5-11e8-9b4b-de4c403df404.png">
