### PR TITLE
X-Accel-Redirect header doesn't end with semicolon

### DIFF
--- a/source/start/topics/examples/xsendfile.rst
+++ b/source/start/topics/examples/xsendfile.rst
@@ -31,7 +31,7 @@ If the application adds an header X-Accel-Redirect for the location ``/protected
 
 .. code-block:: http
 
-   X-Accel-Redirect: /protected/iso.img;
+   X-Accel-Redirect: /protected/iso.img
 
 Then NGINX will serve the file ``/some/path/protected/iso.img`` - note that the root and internal redirect paths are concatenated.
 


### PR DESCRIPTION
when testing it, ending the header with a semicolon caused a 404 not found error for me, but when i removed the trailing semicolon from the header, it worked.