### PR TITLE
source/extending/api/logging.rst: err parameter is an int, not a pointer

### DIFF
--- a/source/extending/api/logging.rst
+++ b/source/extending/api/logging.rst
@@ -55,7 +55,7 @@ ngx_log_stderr
 
    Sends an error to the system's stderr. Accepts a variable list of parameters using printf format placeholders.
 
-   :param err: A pointer to the NGINX logging object
+   :param err: The operating system error code (0 if not applicable)
    :param fmt: The error message text including printf format placeholders
 
 ngx_log_abort
@@ -65,7 +65,7 @@ ngx_log_abort
 
    Aborts NGINX and sends an error message to stderr. Accepts a variable list of parameters using printf format placeholders.
 
-   :param err: A pointer to the NGINX logging object
+   :param err: The operating system error code (0 if not applicable)
    :param fmt: The error message text including printf format placeholders
 
 ngx_log_debug


### PR DESCRIPTION
Previously, the err parameter was incorrectly documented as a pointer
to the NGINX logging object. This is incorrect; err should be the operating
system error code (0 if not applicable).