### PR TITLE
Updating references

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -17,7 +17,7 @@ requests, you can still benefit from NGINX's high-performance and small memory
 footprint. NGINX scales in all directions: from the smallest VPS all the way up
 to large clusters of servers.
 
-NGINX powers several high-visibility sites, such as `Netflix <https://www.netflix.com/>`_, `Hulu <https://www.hulu.com/>`_, `Pinterest <https://www.pinterest.com/>`_, `CloudFlare <https://www.cloudflare.com/>`_, `Airbnb <https://www.airbnb.com/>`_, `WordPress.com <https://wordpress.com/>`_, `GitHub <https://github.com/>`_, `SoundCloud <https://soundcloud.com/>`_, `Zynga <https://www.zynga.com/>`_, `Eventbrite <https://eventbrite.com/>`_, `Zappos <http://www.zappos.com/>`_, `Media Temple <https://mediatemple.net/>`_, `Heroku <https://www.heroku.com/>`_, `RightScale <http://www.rightscale.com/>`_, `Engine Yard <https://www.engineyard.com/>`_, `MaxCDN <https://www.maxcdn.com/>`_ and many others.
+NGINX powers several high-visibility sites, such as `Netflix <https://www.netflix.com/>`_, `Hulu <https://www.hulu.com/>`_, `Pinterest <https://www.pinterest.com/>`_, `CloudFlare <https://www.cloudflare.com/>`_, `Airbnb <https://www.airbnb.com/>`_, `WordPress.com <https://wordpress.com/>`_, `GitHub <https://github.com/>`_, `SoundCloud <https://soundcloud.com/>`_, `Zynga <https://www.zynga.com/>`_, `Eventbrite <https://eventbrite.com/>`_, `Zappos <http://www.zappos.com/>`_, `Media Temple <https://mediatemple.net/>`_, `Heroku <https://www.heroku.com/>`_, `RightScale <http://www.rightscale.com/>`_, `Engine Yard <https://www.engineyard.com/>`_, `StackPath <https://www.stackpath.com/>`_, `CDN77 <https://www.cdn77.com/>`_ and many others.
 
 .. _introtable:
 


### PR DESCRIPTION
MaxCDN has rebranded and integrated into StackPath this summer. CDN77 is another major traffic player using NGINX.