### PR TITLE
Include new learning resource

### DIFF
--- a/source/start/index.rst
+++ b/source/start/index.rst
@@ -242,5 +242,6 @@ Advanced Topics
 Learning Resources
 ------------------
 
+* `NGINX online courses - A collection of online courses from a wide range of providers <https://classpert.com/nginx>`_
 * `Learn NGINX - Top NGINX tutorials ranked by developers <https://gitconnected.com/learn/nginx>`_
 * `Programming Community Curated Resources for learning NGINX <https://hackr.io/tutorials/learn-nginx>`_


### PR DESCRIPTION
We are launching Classpert.com, a meta search engine for online courses. We have a collection of NGINX courses, so I figured it might be useful for newcomers. Please let me know if this kind of proposed edit violates any wiki guidelines (I couldn't find anything about it on the docs)