### PR TITLE
Fix Multisite Regrex

### DIFF
--- a/source/start/topics/recipes/wordpress.rst
+++ b/source/start/topics/recipes/wordpress.rst
@@ -124,7 +124,7 @@ Rewrite rules for Multisite using subdirectories
         root /var/www/example.com/htdocs;
         index index.php;
 
-        location ~ ^(/[^/]+/)?files/(.+) {
+        location ~ ^(/[^/]+)?/files/(.+) {
             try_files /wp-content/blogs.dir/$blogid/files/$2 /wp-includes/ms-files.php?file=$2 ;
             access_log off;	log_not_found off; expires max;
         }


### PR DESCRIPTION
Current Regrex works good for subsite called `hello`  https://example.com/hello/files/2014/02/coco_homepage-treerings_rev2.png but when we mapped domain `https://example.com/hello/` to `hello.com` its breaks images which removed BLOG NAME from URL

https://hello.com/files/2014/02/coco_homepage-treerings_rev2.png