### PR TITLE
Pitfalls: Minor grammatical fix..$request_filename

### DIFF
--- a/source/start/topics/tutorials/config_pitfalls.rst
+++ b/source/start/topics/tutorials/config_pitfalls.rst
@@ -488,7 +488,7 @@ Use ``$request_filename`` for ``SCRIPT_FILENAME``
 
 Use ``$request_filename`` instead of ``$document_root$fastcgi_script_name``.
 
-If use ``alias`` directive with ``$document_root$fastcgi_script_name``, ``$document_root$fastcgi_script_name`` will return the wrong path.
+If you use the ``alias`` directive with ``$document_root$fastcgi_script_name``, ``$document_root$fastcgi_script_name`` will return the wrong path.
 
 BAD:
 


### PR DESCRIPTION
Correct string `If use alias...` to `If you use the alias...`

https://github.com/nginxinc/nginx-wiki/blob/831c873fa9ee1734a50f1b3ee4eb0f24439350d7/source/start/topics/tutorials/config_pitfalls.rst#use-request_filename-for-script_filename

/ 

https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#use-request-filename-for-script-filename