### PR TITLE
Do not return 404 for Drupal updates

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -92,9 +92,9 @@ Recipe
         # pattern with front controllers other than update.php in a future
         # release.
         location ~ '\.php$|^/update.php' {
-            # Ensure the php file exists. Mitigates CVE-2019-11043
-            try_files $uri =404;
             fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
+            # Ensure the php file exists. Mitigates CVE-2019-11043
+            try_files $fastcgi_script_name =404;
             # Security note: If you're running a version of PHP older than the
             # latest 5.3, you should have "cgi.fix_pathinfo = 0;" in php.ini.
             # See http://serverfault.com/q/627903/94922 for details.


### PR DESCRIPTION
Fixes #487 by insuring the script file exists instead of checking the `$uri`.

In the case of updates the `$uri` can be `/update.php/selection` which is not the valid file.