### PR TITLE
Systemd: update to network-online.target ensure network interface is up

### DIFF
--- a/source/start/topics/examples/systemd.rst
+++ b/source/start/topics/examples/systemd.rst
@@ -15,7 +15,8 @@ Save this file as ``/lib/systemd/system/nginx.service``
 
     [Unit]
     Description=The NGINX HTTP and reverse proxy server
-    After=syslog.target network.target remote-fs.target nss-lookup.target
+    After=syslog.target network-online.target remote-fs.target nss-lookup.target
+    Wants=network-online.target
 
     [Service]
     Type=forking


### PR DESCRIPTION
### Backgroud
Nginx always used as a proxy, and the function of [resovler](http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver) and upstream always relay on other service from the network. So Nginx should run after ensure network interface is up.

### Improve
Refer to https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/, we should use to instead of network.target, to ensure network interface is up.

### Related Problem List
https://www.ruby-forum.com/t/nginx-boot-issues-with-centos7/241774
https://bugs.launchpad.net/ubuntu/+source/nginx/+bug/1850272
https://github.com/openresty/openresty/issues/590