### PR TITLE
Fix link to error_log in Separating logs per host

### DIFF
--- a/source/start/topics/examples/separateerrorloggingpervirtualhost.rst
+++ b/source/start/topics/examples/separateerrorloggingpervirtualhost.rst
@@ -42,5 +42,5 @@ This way, a request for ``one.org/nonexistent.html`` file will output the follow
 
   2009/01/01 19:45:44 [error]  29874#0: *98 open() "/var/www/one/nonexistent.html" failed (2: No such file or directory), client: 11.22.33.44, server: one.org, request: "GET /nonexistent.html HTTP/1.1", host: "one.org"
 
-.. note:: The `error_log <https://nginx.org/en/docs/http/ngx_http_core_module.html#error_log>`_ directive has different default values depending on the section it appears in.
+.. note:: The `error_log <https://nginx.org/en/docs/ngx_core_module.html#error_log>`_ directive has different default values depending on the section it appears in.
   This means that you have to explicitly set the error logging level in the `server {...} <https://nginx.org/en/docs/http/ngx_http_core_module.html#server>`_ block.


### PR DESCRIPTION
At https://www.nginx.com/resources/wiki/start/topics/examples/separateerrorloggingpervirtualhost/, the link to error_log was broken