### PR TITLE
Replicate Drupal's .htaccess FileMatch rules

### DIFF
--- a/source/start/topics/recipes/drupal.rst
+++ b/source/start/topics/recipes/drupal.rst
@@ -80,9 +80,9 @@ Recipe
             deny all;
             return 404;
         }
-        
+
         # Protect files and directories from prying eyes.
-        location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|composer\.(lock|json)$|web\.config$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
+        location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|/(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config)$|/#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
             deny all;
             return 404;
         }


### PR DESCRIPTION
The difference in behaviour is because the original [`.htaccess`](https://github.com/drupal/drupal/blob/8e416f130c136cab02aa0882793c85e219bbf442/.htaccess#L6) rule matches file names, whereas nginx is matching against a location path (which must all start with a `/`).

The ported regex failed to match specifically because of the use of `^`, which should be replaced with a `/` or `^/` instead depending on your use case.

Using `/` makes more sense since that designates the start of the filename which is what the original htaccess rules did.

References: 
- https://www.askapache.com/htaccess/using-filesmatch-and-files-in-htaccess/
- https://httpd.apache.org/docs/2.4/mod/core.html#location (is the equivalent Apache rule, which starts with a `/`)