### PR TITLE
docs: fix spell error

### DIFF
--- a/source/modules/upload_progress.rst
+++ b/source/modules/upload_progress.rst
@@ -161,7 +161,7 @@ upload.
 upload\_progress\_content\_type
 -------------------------------
 :Syntax: *upload\_progress\_content\_type*
-:Default: *test/javascript*
+:Default: *text/javascript*
 :Context: *location*
 
 This directive allows to change the upload progress probe response


### PR DESCRIPTION
Content Type: test/javascript  ==> Content Type: text/javascript